### PR TITLE
Support for IDateTimeToggleValueProvider in all 3 Azure providers

### DIFF
--- a/src/FeatureToggle.Azure.DocumentDB/FeatureToggle.Azure.DocumentDB.csproj
+++ b/src/FeatureToggle.Azure.DocumentDB/FeatureToggle.Azure.DocumentDB.csproj
@@ -9,10 +9,13 @@
     <Copyright>Copyright © 2018</Copyright>
     <RepositoryType>Git</RepositoryType>
     <RepositoryUrl>https://github.com/mikanyg/FeatureToggle.Azure.git</RepositoryUrl>
-    <PackageReleaseNotes>1.0.0
+    <PackageReleaseNotes>1.1.0
+- Provider implements IDateTimeToggleValueProvider. Can be used as provider for feature toggles inheriting from FeatureToggle.EnabledOnOrAfterDateFeatureToggle or FeatureToggle.EnabledOnOrBeforeDateFeatureToggle.
+1.0.0
 - Initial release</PackageReleaseNotes>
     <PackageTags>FeatureToggle Toggle Azure DocumentDB DocDB CosmosDB NetStandard</PackageTags>
     <Description>FeatureToggle provider for storing feature toggles in Azure DocumentDB.</Description>
+    <Version>1.1.0</Version>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/FeatureToggle.Azure.DocumentDB/Providers/BooleanFeatureToggleDocument.cs
+++ b/src/FeatureToggle.Azure.DocumentDB/Providers/BooleanFeatureToggleDocument.cs
@@ -1,0 +1,14 @@
+﻿namespace FeatureToggle.Azure.Providers
+{
+    public class BooleanFeatureToggleDocument : FeatureToggleDocument
+    {
+        public BooleanFeatureToggleDocument() : base() { }        
+
+        public BooleanFeatureToggleDocument(string toggleName) : base(toggleName)
+        {            
+            Enabled = false;
+        }
+                
+        public bool Enabled { get; set; }
+    }
+}

--- a/src/FeatureToggle.Azure.DocumentDB/Providers/DateTimeFeatureToggleDocument.cs
+++ b/src/FeatureToggle.Azure.DocumentDB/Providers/DateTimeFeatureToggleDocument.cs
@@ -1,0 +1,16 @@
+﻿using System;
+
+namespace FeatureToggle.Azure.Providers
+{
+    public class DateTimeFeatureToggleDocument : FeatureToggleDocument
+    {
+        public DateTimeFeatureToggleDocument() : base() { }
+
+        public DateTimeFeatureToggleDocument(string toggleName) : base(toggleName)
+        {            
+            Toggle = default(DateTime);
+        }
+                
+        public DateTime Toggle { get; set; }
+    }
+}

--- a/src/FeatureToggle.Azure.DocumentDB/Providers/DateTimeFeatureToggleDocument.cs
+++ b/src/FeatureToggle.Azure.DocumentDB/Providers/DateTimeFeatureToggleDocument.cs
@@ -8,9 +8,9 @@ namespace FeatureToggle.Azure.Providers
 
         public DateTimeFeatureToggleDocument(string toggleName) : base(toggleName)
         {            
-            Toggle = default(DateTime);
+            ToggleTimestamp = default(DateTime);
         }
                 
-        public DateTime Toggle { get; set; }
+        public DateTime ToggleTimestamp { get; set; }
     }
 }

--- a/src/FeatureToggle.Azure.DocumentDB/Providers/DocumentDbProvider.cs
+++ b/src/FeatureToggle.Azure.DocumentDB/Providers/DocumentDbProvider.cs
@@ -7,7 +7,7 @@ using System.Net;
 
 namespace FeatureToggle.Azure.Providers
 {
-    public class DocumentDbProvider : IBooleanToggleValueProvider
+    public class DocumentDbProvider : IBooleanToggleValueProvider, IDateTimeToggleValueProvider
     {
         private static bool _collectionVerified;
 
@@ -35,42 +35,55 @@ namespace FeatureToggle.Azure.Providers
 
         public bool EvaluateBooleanToggleValue(IFeatureToggle toggle)
         {
+            return EvaluateToggleValue(toggle, document => document.Enabled, toggleName => new BooleanFeatureToggleDocument(toggleName));
+        }
+
+        public DateTime EvaluateDateTimeToggleValue(IFeatureToggle toggle)
+        {
+            return EvaluateToggleValue(toggle, document => document.Toggle, toggleName => new DateTimeFeatureToggleDocument(toggleName));
+        }
+
+        private TToggleValue EvaluateToggleValue<TDocument, TToggleValue>(IFeatureToggle toggle, Func<TDocument, TToggleValue> valueEvaluatorFunc, Func<string, TDocument> newDocumentFunc) where TDocument : FeatureToggleDocument
+        {
             var client = GetDocumentClient();
 
             var toggleName = toggle.GetType().Name;
 
-            bool toggleValue;
+            TToggleValue toggleValue;
 
             try
             {
                 // Fetch feature toggle
-                var reponse = client.ReadDocumentAsync<FeatureToggleDocument>(
+                var response = client.ReadDocumentAsync<TDocument>(
                     UriFactory.CreateDocumentUri(Configuration.DatabaseId, Configuration.CollectionId, toggleName)).Result;
 
-                toggleValue = reponse.Document.Enabled;
+                var document = response.Document;
+
+                toggleValue = valueEvaluatorFunc(document);
             }
             catch (AggregateException ae) when (ae.InnerExceptions.First() is DocumentClientException ex && ex.StatusCode == HttpStatusCode.NotFound)
             {
                 Trace.TraceWarning($"Feature toggle '{toggleName}' not found.");
 
-                toggleValue = HandleMissingToggle(toggleName, client);
+                var newDocument = HandleMissingToggle(toggleName, () => newDocumentFunc(toggleName), client);
+                toggleValue = valueEvaluatorFunc(newDocument);
             }
-            
+
             return toggleValue;
         }
 
-        private bool HandleMissingToggle(string toggleName, DocumentClient client)
+        private TDocument HandleMissingToggle<TDocument>(string toggleName, Func<TDocument> newDocumentFunc, DocumentClient client) where TDocument : FeatureToggleDocument
         {
             if (!Configuration.AutoCreateFeature)
                 throw new ToggleConfigurationError($"Feature toggle '{toggleName}' does not exist. Either create it manually or configure the provider to auto create it.");
 
             Trace.TraceInformation($"AutoCreateFeature enabled, creating feature toggle '{toggleName}'.");
 
-            var document = new FeatureToggleDocument(toggleName);
+            var document = newDocumentFunc();
             var response = client.CreateDocumentAsync(
                 UriFactory.CreateDocumentCollectionUri(Configuration.DatabaseId, Configuration.CollectionId), document, disableAutomaticIdGeneration:true).Result;
 
-            return document.Enabled;
+            return document;
         }
 
         private DocumentClient GetDocumentClient()
@@ -105,6 +118,6 @@ namespace FeatureToggle.Azure.Providers
             _collectionVerified = true;
 
             return client;
-        }
+        }        
     }
 }

--- a/src/FeatureToggle.Azure.DocumentDB/Providers/DocumentDbProvider.cs
+++ b/src/FeatureToggle.Azure.DocumentDB/Providers/DocumentDbProvider.cs
@@ -43,13 +43,13 @@ namespace FeatureToggle.Azure.Providers
             return EvaluateToggleValue(toggle, document => document.ToggleTimestamp, toggleName => new DateTimeFeatureToggleDocument(toggleName));
         }
 
-        private TToggleValue EvaluateToggleValue<TDocument, TToggleValue>(IFeatureToggle toggle, Func<TDocument, TToggleValue> valueSelector, Func<string, TDocument> documentCreator) where TDocument : FeatureToggleDocument
+        private TValue EvaluateToggleValue<TDocument, TValue>(IFeatureToggle toggle, Func<TDocument, TValue> valueSelector, Func<string, TDocument> documentCreator) where TDocument : FeatureToggleDocument
         {
             var client = GetDocumentClient();
 
             var toggleName = toggle.GetType().Name;
 
-            TToggleValue toggleValue;
+            TValue toggleValue;
 
             try
             {

--- a/src/FeatureToggle.Azure.DocumentDB/Providers/DocumentDbProvider.cs
+++ b/src/FeatureToggle.Azure.DocumentDB/Providers/DocumentDbProvider.cs
@@ -40,7 +40,7 @@ namespace FeatureToggle.Azure.Providers
 
         public DateTime EvaluateDateTimeToggleValue(IFeatureToggle toggle)
         {
-            return EvaluateToggleValue(toggle, document => document.Toggle, toggleName => new DateTimeFeatureToggleDocument(toggleName));
+            return EvaluateToggleValue(toggle, document => document.ToggleTimestamp, toggleName => new DateTimeFeatureToggleDocument(toggleName));
         }
 
         private TToggleValue EvaluateToggleValue<TDocument, TToggleValue>(IFeatureToggle toggle, Func<TDocument, TToggleValue> valueSelector, Func<string, TDocument> documentCreator) where TDocument : FeatureToggleDocument

--- a/src/FeatureToggle.Azure.DocumentDB/Providers/FeatureToggleDocument.cs
+++ b/src/FeatureToggle.Azure.DocumentDB/Providers/FeatureToggleDocument.cs
@@ -3,18 +3,16 @@ using System;
 
 namespace FeatureToggle.Azure.Providers
 {
-    public class FeatureToggleDocument
+    public abstract class FeatureToggleDocument
     {
-        public FeatureToggleDocument() { }
+        protected FeatureToggleDocument() { }
 
-        public FeatureToggleDocument(string toggleName)
+        protected FeatureToggleDocument(string toggleName)
         {
-            Id = toggleName ?? throw new ArgumentNullException(nameof(toggleName));
-            Enabled = false;
+            Id = toggleName ?? throw new ArgumentNullException(nameof(toggleName));            
         }
 
         [JsonProperty(PropertyName = "id")]
-        public string Id { get; set; }
-        public bool Enabled { get; set; }
+        public string Id { get; set; }        
     }
 }

--- a/src/FeatureToggle.Azure.ServiceFabric/FeatureToggle.Azure.ServiceFabric.csproj
+++ b/src/FeatureToggle.Azure.ServiceFabric/FeatureToggle.Azure.ServiceFabric.csproj
@@ -9,10 +9,13 @@
     <Copyright>Copyright © 2018</Copyright>
     <RepositoryType>Git</RepositoryType>
     <RepositoryUrl>https://github.com/mikanyg/FeatureToggle.Azure.git</RepositoryUrl>
-    <PackageReleaseNotes>1.0.0
+    <PackageReleaseNotes>1.1.0
+- Provider implements IDateTimeToggleValueProvider. Can be used as provider for feature toggles inheriting from FeatureToggle.EnabledOnOrAfterDateFeatureToggle or FeatureToggle.EnabledOnOrBeforeDateFeatureToggle.
+1.0.0
 - Initial release</PackageReleaseNotes>
     <PackageTags>FeatureToggle Toggle Azure ServiceFabric Fabric NetStandard</PackageTags>
     <Description>FeatureToggle provider for storing feature toggles in Service Fabric configuration packages.</Description>
+    <Version>1.1.0</Version>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/FeatureToggle.Azure.ServiceFabric/Providers/ServiceFabricConfigProvider.cs
+++ b/src/FeatureToggle.Azure.ServiceFabric/Providers/ServiceFabricConfigProvider.cs
@@ -4,7 +4,7 @@ using System.Linq;
 
 namespace FeatureToggle.Azure.Providers
 {
-    public class ServiceFabricConfigProvider : IBooleanToggleValueProvider
+    public class ServiceFabricConfigProvider : IBooleanToggleValueProvider, IDateTimeToggleValueProvider
     {
         private const string KeyNotFoundInSettingsMessage = "The key '{0}' was not found in settings.xml";
 
@@ -39,6 +39,19 @@ namespace FeatureToggle.Azure.Providers
             var configValue = GetConfigValue(key);
 
             return ParseBooleanConfigString(configValue, key);
+        }
+
+        public DateTime EvaluateDateTimeToggleValue(IFeatureToggle toggle)
+        {
+            var key = ExpectedAppSettingsKeyFor(toggle);
+
+            ValidateKeyExists(key);
+
+            var configValue = GetConfigValue(key);
+
+            var parser = new ConfigurationDateParser();
+
+            return parser.ParseDateTimeConfigString(configValue, key);
         }
 
         private string ExpectedAppSettingsKeyFor(IFeatureToggle toggle)
@@ -88,6 +101,6 @@ namespace FeatureToggle.Azure.Providers
             
             var section = settings.Sections[Configuration.ConfigSectionName];
             return section.Parameters.Select(p => p.Name).ToArray();
-        }
+        }        
     }
 }

--- a/src/FeatureToggle.Azure.TableStorage/FeatureToggle.Azure.TableStorage.csproj
+++ b/src/FeatureToggle.Azure.TableStorage/FeatureToggle.Azure.TableStorage.csproj
@@ -9,10 +9,13 @@
     <Copyright>Copyright © 2018</Copyright>
     <RepositoryType>Git</RepositoryType>
     <RepositoryUrl>https://github.com/mikanyg/FeatureToggle.Azure.git</RepositoryUrl>
-    <PackageReleaseNotes>1.0.0
+    <PackageReleaseNotes>1.1.0
+- Provider implements IDateTimeToggleValueProvider. Can be used as provider for feature toggles inheriting from FeatureToggle.EnabledOnOrAfterDateFeatureToggle or FeatureToggle.EnabledOnOrBeforeDateFeatureToggle.
+1.0.0
 - Initial release</PackageReleaseNotes>
     <PackageTags>FeatureToggle Toggle Azure TableStorage Table Storage NetStandard</PackageTags>
     <Description>FeatureToggle provider for storing feature toggles in Azure Table storage.</Description>
+    <Version>1.1.0</Version>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/FeatureToggle.Azure.TableStorage/Providers/BooleanFeatureToggleEntity.cs
+++ b/src/FeatureToggle.Azure.TableStorage/Providers/BooleanFeatureToggleEntity.cs
@@ -1,0 +1,14 @@
+﻿namespace FeatureToggle.Azure.Providers
+{
+    public class BooleanFeatureToggleEntity : FeatureToggleEntity
+    {
+        public BooleanFeatureToggleEntity() : base() { }
+
+        public BooleanFeatureToggleEntity(string componentName, string toggleName) : base(componentName, toggleName)
+        {
+            Enabled = false;
+        }
+
+        public bool Enabled { get; set; }
+    }
+}

--- a/src/FeatureToggle.Azure.TableStorage/Providers/DateTimeFeatureToggleEntity.cs
+++ b/src/FeatureToggle.Azure.TableStorage/Providers/DateTimeFeatureToggleEntity.cs
@@ -8,9 +8,9 @@ namespace FeatureToggle.Azure.Providers
 
         public DateTimeFeatureToggleEntity(string componentName, string toggleName) : base(componentName, toggleName)
         {
-            Toggle = default(DateTime);
+            ToggleTimestamp = new DateTime(1900, 1, 1); // Table Storage does not support DateTime.Min
         }
 
-        public DateTime Toggle { get; set; }
+        public DateTime ToggleTimestamp { get; set; }
     }
 }

--- a/src/FeatureToggle.Azure.TableStorage/Providers/DateTimeFeatureToggleEntity.cs
+++ b/src/FeatureToggle.Azure.TableStorage/Providers/DateTimeFeatureToggleEntity.cs
@@ -1,0 +1,16 @@
+﻿using System;
+
+namespace FeatureToggle.Azure.Providers
+{
+    public class DateTimeFeatureToggleEntity : FeatureToggleEntity
+    {
+        public DateTimeFeatureToggleEntity() : base() { }
+
+        public DateTimeFeatureToggleEntity(string componentName, string toggleName) : base(componentName, toggleName)
+        {
+            Toggle = default(DateTime);
+        }
+
+        public DateTime Toggle { get; set; }
+    }
+}

--- a/src/FeatureToggle.Azure.TableStorage/Providers/FeatureToggleEntity.cs
+++ b/src/FeatureToggle.Azure.TableStorage/Providers/FeatureToggleEntity.cs
@@ -3,17 +3,14 @@ using System;
 
 namespace FeatureToggle.Azure.Providers
 {
-    public class FeatureToggleEntity : TableEntity
+    public abstract class FeatureToggleEntity : TableEntity
     {
-        public FeatureToggleEntity() { }
+        protected FeatureToggleEntity() { }
 
-        public FeatureToggleEntity(string componentName, string toggleName)
+        protected FeatureToggleEntity(string componentName, string toggleName)
         {
             PartitionKey = componentName ?? throw new ArgumentNullException(nameof(componentName));
-            RowKey = toggleName ?? throw new ArgumentNullException(nameof(toggleName));
-            Enabled = false;
-        }
-
-        public bool Enabled { get; set; }
+            RowKey = toggleName ?? throw new ArgumentNullException(nameof(toggleName));            
+        }        
     }
 }

--- a/src/FeatureToggle.Azure.TableStorage/Providers/TableStorageProvider.cs
+++ b/src/FeatureToggle.Azure.TableStorage/Providers/TableStorageProvider.cs
@@ -33,7 +33,7 @@ namespace FeatureToggle.Azure.Providers
 
         public DateTime EvaluateDateTimeToggleValue(IFeatureToggle toggle)
         {
-            return EvaluateToggleValue(toggle, entity => entity.Toggle, (componentName, toggleName) => new DateTimeFeatureToggleEntity(componentName, toggleName));
+            return EvaluateToggleValue(toggle, entity => entity.ToggleTimestamp, (componentName, toggleName) => new DateTimeFeatureToggleEntity(componentName, toggleName));
         }
 
         private TValue EvaluateToggleValue<TEntity, TValue>(IFeatureToggle toggle, Func<TEntity, TValue> valueSelector, Func<string, string, TEntity> entityCreator) where TEntity : FeatureToggleEntity

--- a/src/FeatureToggle.Azure.TableStorage/Providers/TableStorageProvider.cs
+++ b/src/FeatureToggle.Azure.TableStorage/Providers/TableStorageProvider.cs
@@ -1,11 +1,11 @@
-﻿using System;
-using System.Diagnostics;
-using Microsoft.WindowsAzure.Storage;
+﻿using Microsoft.WindowsAzure.Storage;
 using Microsoft.WindowsAzure.Storage.Table;
+using System;
+using System.Diagnostics;
 
 namespace FeatureToggle.Azure.Providers
 {
-    public class TableStorageProvider : IBooleanToggleValueProvider
+    public class TableStorageProvider : IBooleanToggleValueProvider, IDateTimeToggleValueProvider
     {
         private static bool _tableVerified;
 
@@ -28,42 +28,53 @@ namespace FeatureToggle.Azure.Providers
 
         public bool EvaluateBooleanToggleValue(IFeatureToggle toggle)
         {
+            return EvaluateToggleValue(toggle, entity => entity.Enabled, (componentName, toggleName) => new BooleanFeatureToggleEntity(componentName, toggleName));
+        }
+
+        public DateTime EvaluateDateTimeToggleValue(IFeatureToggle toggle)
+        {
+            return EvaluateToggleValue(toggle, entity => entity.Toggle, (componentName, toggleName) => new DateTimeFeatureToggleEntity(componentName, toggleName));
+        }
+
+        private TValue EvaluateToggleValue<TEntity, TValue>(IFeatureToggle toggle, Func<TEntity, TValue> valueSelector, Func<string, string, TEntity> entityCreator) where TEntity : FeatureToggleEntity
+        {
             var table = GetCloudTable();
-            
+
             var componentName = Configuration.PartitionKeyResolver(toggle); // Defaults to assembly name of the feature toggle (used as partitionkey)
             var toggleName = toggle.GetType().Name;
 
             // Fetch feature toggle
             var retrievedResult = table.ExecuteAsync(
-                TableOperation.Retrieve<FeatureToggleEntity>(componentName, toggleName)).Result;
+                TableOperation.Retrieve<TEntity>(componentName, toggleName)).Result;
 
-            bool toggleValue;
-            
-            if (retrievedResult.Result is FeatureToggleEntity featureToggle)
+            TValue toggleValue;
+
+            if (retrievedResult.Result is TEntity entity)
             {
-                toggleValue = featureToggle.Enabled;
+                toggleValue = valueSelector(entity);
             }
             else
             {
                 Trace.TraceWarning($"Feature toggle '{toggleName}' not found.");
 
-                toggleValue = HandleMissingToggle(toggleName, componentName, table);
+                var newEntity = HandleMissingToggle(toggleName, () => entityCreator(componentName, toggleName), table);
+                toggleValue = valueSelector(newEntity);
             }
 
             return toggleValue;
-        }
+        }        
 
-        private bool HandleMissingToggle(string toggleName, string componentName, CloudTable table)
+        private TEntity HandleMissingToggle<TEntity>(string toggleName, Func<TEntity> entityCreator, CloudTable table) where TEntity : FeatureToggleEntity
         {
             if (!Configuration.AutoCreateFeature)
                 throw new ToggleConfigurationError($"Feature toggle '{toggleName}' does not exist. Either create it manually or configure the provider to auto create it.");
 
             Trace.TraceInformation($"AutoCreateFeature enabled, creating feature toggle '{toggleName}'.");
 
-            var entity = new FeatureToggleEntity(componentName, toggleName);
+            var entity = entityCreator();
             var result = table.ExecuteAsync(TableOperation.Insert(entity)).Result;
 
-            return entity.Enabled;
+            return entity;
         }
 
         private CloudTable GetCloudTable()
@@ -91,6 +102,6 @@ namespace FeatureToggle.Azure.Providers
             _tableVerified = true;
 
             return table;
-        }
+        }        
     }
 }


### PR DESCRIPTION
All 3 FeatureToggle providers now implement `FeatureToggle.IDateTimeToggleValueProvider` which makes it possible to support feature toggles inheriting from `FeatureToggle.EnabledOnOrBeforeDateFeatureToggle` and `FeatureToggle.EnabledOnOrAfterDateFeatureToggle`.

Refactored provider logic to more generic structure to enable support for more interface IsomethingToggleValueProvider implementations from core FeatureToggle namespace.