### PR TITLE
Unit test of central storage providers

### DIFF
--- a/FeatureToggle.Azure.sln
+++ b/FeatureToggle.Azure.sln
@@ -9,6 +9,8 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "FeatureToggle.Azure.Documen
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "FeatureToggle.Azure.ServiceFabric", "src\FeatureToggle.Azure.ServiceFabric\FeatureToggle.Azure.ServiceFabric.csproj", "{1CDF4589-A0B2-4B15-AD70-D83DD489F055}"
 EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "FeatureToggle.Azure.DocumentDB.Test", "test\FeatureToggle.Azure.DocumentDB.Test\FeatureToggle.Azure.DocumentDB.Test.csproj", "{9AF9253E-C558-44C1-8883-10C353F55A51}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -27,6 +29,10 @@ Global
 		{1CDF4589-A0B2-4B15-AD70-D83DD489F055}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{1CDF4589-A0B2-4B15-AD70-D83DD489F055}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{1CDF4589-A0B2-4B15-AD70-D83DD489F055}.Release|Any CPU.Build.0 = Release|Any CPU
+		{9AF9253E-C558-44C1-8883-10C353F55A51}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{9AF9253E-C558-44C1-8883-10C353F55A51}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{9AF9253E-C558-44C1-8883-10C353F55A51}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{9AF9253E-C558-44C1-8883-10C353F55A51}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/FeatureToggle.Azure.sln
+++ b/FeatureToggle.Azure.sln
@@ -11,6 +11,14 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "FeatureToggle.Azure.Service
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "FeatureToggle.Azure.DocumentDB.Test", "test\FeatureToggle.Azure.DocumentDB.Test\FeatureToggle.Azure.DocumentDB.Test.csproj", "{9AF9253E-C558-44C1-8883-10C353F55A51}"
 EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "DocumentDB", "DocumentDB", "{CB1A56C2-DD8C-4C7F-99DA-895BBA967FC6}"
+EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "TableStorage", "TableStorage", "{01199EBA-AB76-44E1-AFBE-B1E36BF788C7}"
+EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "ServiceFabric", "ServiceFabric", "{E8D38200-46E2-4434-82E2-DD86644B78A1}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "FeatureToggle.Azure.TableStorage.Test", "test\FeatureToggle.Azure.TableStorage.Test\FeatureToggle.Azure.TableStorage.Test.csproj", "{00F46000-D1C8-4900-8EB5-63A89EDCAA12}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -33,9 +41,20 @@ Global
 		{9AF9253E-C558-44C1-8883-10C353F55A51}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{9AF9253E-C558-44C1-8883-10C353F55A51}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{9AF9253E-C558-44C1-8883-10C353F55A51}.Release|Any CPU.Build.0 = Release|Any CPU
+		{00F46000-D1C8-4900-8EB5-63A89EDCAA12}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{00F46000-D1C8-4900-8EB5-63A89EDCAA12}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{00F46000-D1C8-4900-8EB5-63A89EDCAA12}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{00F46000-D1C8-4900-8EB5-63A89EDCAA12}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
+	EndGlobalSection
+	GlobalSection(NestedProjects) = preSolution
+		{425E60D9-9821-49D8-8047-88ABE8856563} = {01199EBA-AB76-44E1-AFBE-B1E36BF788C7}
+		{0EEE00A5-C84E-4E7B-832A-D1CD4F9AA34F} = {CB1A56C2-DD8C-4C7F-99DA-895BBA967FC6}
+		{1CDF4589-A0B2-4B15-AD70-D83DD489F055} = {E8D38200-46E2-4434-82E2-DD86644B78A1}
+		{9AF9253E-C558-44C1-8883-10C353F55A51} = {CB1A56C2-DD8C-4C7F-99DA-895BBA967FC6}
+		{00F46000-D1C8-4900-8EB5-63A89EDCAA12} = {01199EBA-AB76-44E1-AFBE-B1E36BF788C7}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {F39C8383-A0E2-4F37-BC1F-7A23D75A57DD}

--- a/test/FeatureToggle.Azure.DocumentDB.Test/DateTimeToggleTest.cs
+++ b/test/FeatureToggle.Azure.DocumentDB.Test/DateTimeToggleTest.cs
@@ -1,0 +1,71 @@
+﻿using FeatureToggle.Azure.DocumentDB.Test.Toggles;
+using FeatureToggle.Azure.Providers;
+using NUnit.Framework;
+using Shouldly;
+using System;
+using System.Collections.Generic;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace FeatureToggle.Azure.DocumentDB.Test
+{
+    [TestFixture]
+    public class DateTimeToggleTest : DocumentDbTestFixture
+    {
+        [Test]
+        public async Task FeatureEnabled_ExpiringFeatureToggleSetToExpireYesterday_ToggleValueIsFalse()
+        {
+            // Arrange
+            AutoCreateToggle<ExpiringTestFeatureToggle>();
+            await UpdateToggleDocument(new DateTimeFeatureToggleDocument(nameof(ExpiringTestFeatureToggle)) { ToggleTimestamp = DateTime.Today.AddDays(-1) });
+
+            var toggle = new ExpiringTestFeatureToggle();
+            // Act
+            var toggleValue = toggle.FeatureEnabled;
+            // Assert
+            toggleValue.ShouldBeFalse();
+        }
+
+        [Test]
+        public async Task FeatureEnabled_ExpiringFeatureToggleSetToExpireTomorrow_ToggleValueIsTrue()
+        {
+            // Arrange
+            AutoCreateToggle<ExpiringTestFeatureToggle>();
+            await UpdateToggleDocument(new DateTimeFeatureToggleDocument(nameof(ExpiringTestFeatureToggle)) { ToggleTimestamp = DateTime.Today.AddDays(1) });
+
+            var toggle = new ExpiringTestFeatureToggle();
+            // Act
+            var toggleValue = toggle.FeatureEnabled;
+            // Assert
+            toggleValue.ShouldBeTrue();
+        }
+
+        [Test]
+        public async Task FeatureEnabled_CominSoonFeatureToggleSetToEnabledYesterday_ToggleValueIsTrue()
+        {
+            // Arrange
+            AutoCreateToggle<ComingSoonTestFeatureToggle>();
+            await UpdateToggleDocument(new DateTimeFeatureToggleDocument(nameof(ComingSoonTestFeatureToggle)) { ToggleTimestamp = DateTime.Today.AddDays(-1) });
+
+            var toggle = new ComingSoonTestFeatureToggle();
+            // Act
+            var toggleValue = toggle.FeatureEnabled;
+            // Assert
+            toggleValue.ShouldBeTrue();
+        }
+
+        [Test]
+        public async Task FeatureEnabled_ComingSoonFeatureToggleSetToEnabledTomorrow_ToggleValueIsFalse()
+        {
+            // Arrange
+            AutoCreateToggle<ComingSoonTestFeatureToggle>();
+            await UpdateToggleDocument(new DateTimeFeatureToggleDocument(nameof(ComingSoonTestFeatureToggle)) { ToggleTimestamp = DateTime.Today.AddDays(1) });
+
+            var toggle = new ComingSoonTestFeatureToggle();
+            // Act
+            var toggleValue = toggle.FeatureEnabled;
+            // Assert
+            toggleValue.ShouldBeFalse();
+        }
+    }
+}

--- a/test/FeatureToggle.Azure.DocumentDB.Test/DocumentDbProviderTest.cs
+++ b/test/FeatureToggle.Azure.DocumentDB.Test/DocumentDbProviderTest.cs
@@ -1,3 +1,4 @@
+using FeatureToggle.Azure.DocumentDB.Test.Toggles;
 using FeatureToggle.Azure.Providers;
 using Microsoft.Azure.Documents.Client;
 using NUnit.Framework;
@@ -104,7 +105,7 @@ namespace FeatureToggle.Azure.DocumentDB.Test
         public async Task EvaluateBooleanToggleValue_ToggleExists_ToggleValueIsTrue()
         {
             // Arrange
-            AutoCreateToggle();
+            AutoCreateToggle<TestFeatureToggle>();
 
             var document = new BooleanFeatureToggleDocument(nameof(TestFeatureToggle)) { Enabled = true };
             await UpdateToggleDocument(document);
@@ -119,7 +120,7 @@ namespace FeatureToggle.Azure.DocumentDB.Test
         public async Task EvaluateDateTimeToggleValue_ToggleExists_ToggleValueIsToday()
         {
             // Arrange
-            AutoCreateToggle();
+            AutoCreateToggle<TestFeatureToggle>();
 
             var document = new DateTimeFeatureToggleDocument(nameof(TestFeatureToggle)) { ToggleTimestamp = DateTime.Today };
             await UpdateToggleDocument(document);

--- a/test/FeatureToggle.Azure.DocumentDB.Test/DocumentDbProviderTest.cs
+++ b/test/FeatureToggle.Azure.DocumentDB.Test/DocumentDbProviderTest.cs
@@ -1,38 +1,167 @@
 using FeatureToggle.Azure.Providers;
-using FeatureToggle.Azure.Toggles;
 using Microsoft.Azure.Documents.Client;
 using Moq;
+using NUnit.Framework;
 using Shouldly;
 using System;
-using Xunit;
+using System.Reflection;
+using System.Threading.Tasks;
 
-namespace FeatureToggle.Azure.Test
+namespace FeatureToggle.Azure.DocumentDB.Test
 {
+    [TestFixture]
     public class DocumentDbProviderTest
     {
-        class TestableProvider : DocumentDbProvider
+        private string databaseId;
+        private string collectionId;
+        private DocumentClient client;
+
+        [SetUp]
+        public void Setup()
         {
-            protected override DocumentClient CreateDocumentClient()
+            client = new DocumentClient(new Uri(TestConfig.ValidEndpoint), TestConfig.ValidAuthKey);
+
+            databaseId = $"FeatureToggle_{Guid.NewGuid()}_Test";
+            collectionId = $"Toggles_{Guid.NewGuid()}_Test";
+
+            // Reset docdb collection validation in provider
+            var field = typeof(DocumentDbProvider).GetField("_collectionVerified", BindingFlags.Static | BindingFlags.NonPublic);            
+            field.SetValue(null, false);
+        }
+
+        [TearDown]
+        public async Task Cleanup()
+        {
+            try
             {
-                return new Mock<DocumentClient>().Object;
+                await client.DeleteDocumentAsync(UriFactory.CreateDocumentUri("FeatureToggle", "Toggles", nameof(TestFeatureToggle)));
             }
-        }
+            catch { }
 
-        class TestToggle : DocumentDbToggle
-        {
-            public TestToggle()
+            try
             {
-                ToggleValueProvider =  new TestableProvider();
+                await client.DeleteDocumentCollectionAsync(UriFactory.CreateDocumentCollectionUri(databaseId, collectionId));
             }
-        }
+            catch { }
 
-        [Fact]
-        public void Test1()
+            try
+            {
+                await client.DeleteDatabaseAsync(UriFactory.CreateDatabaseUri(databaseId));
+            }
+            catch { }
+        }        
+
+        [Test]
+        public void SimpleConfiguration_ValidEndpointAndAuthKeyToggleDoesNotExist_ThrowsToggleConfigurationError()
         {
-            DocumentDbProvider.Configure("someendpont", "someauthkey");
-            var toggle = new TestToggle();
-
-            toggle.FeatureEnabled.ShouldBeTrue();
+            // Arrange
+            DocumentDbProvider.Configure(TestConfig.ValidEndpoint, TestConfig.ValidAuthKey);
+            var toggle = new TestFeatureToggle();
+            // Act and Assert
+            Should.Throw<ToggleConfigurationError>(() =>
+            {
+                var toggleValue = toggle.FeatureEnabled;
+            });
         }
+
+        [Test]
+        public void SimpleConfiguration_EndpointIsNull_ThrowsArgumentException()
+        {   
+            // Act and Assert
+            Should.Throw<ArgumentException>(() =>
+            {
+                DocumentDbProvider.Configure(null, TestConfig.ValidAuthKey);
+            });
+        }
+
+        [Test]
+        public void SimpleConfiguration_AuthKeyIsNull_ThrowsArgumentException()
+        {            
+            // Act and Assert
+            Should.Throw<ArgumentException>(() =>
+            {
+                DocumentDbProvider.Configure(TestConfig.ValidEndpoint, null);
+            });
+        }
+
+        [Test]
+        public void FullConfiguration_ConfigIsNull_ThrowsAgurmentNullException()
+        {
+            // Act and Assert
+            Should.Throw<ArgumentNullException>(() =>
+            {
+                DocumentDbProvider.Configure(null);
+            });
+        }
+
+        [Test]
+        public void FullConfiguration_AutoCreateDbAndCollectionAndToggleDoesNotExist_ThrowsToggleConfigurationError()
+        {
+            // Arrange
+            var config = TestConfig.ValidConfig(databaseId, collectionId);
+            config.AutoCreateDatabaseAndCollection = true;
+
+            DocumentDbProvider.Configure(config);
+            var toggle = new TestFeatureToggle();
+            // Act and Assert
+            Should.Throw<ToggleConfigurationError>(() =>
+            {
+                var toggleValue = toggle.FeatureEnabled;
+            });
+        }
+
+        [Test]
+        public void FullConfiguration_AutoCreateToggleAndDbAndCollectionDoesNotExist_ThrowsToggleConfigurationError()
+        {
+            // Arrange
+            var config = TestConfig.ValidConfig(databaseId, collectionId);
+            config.AutoCreateFeature = true;
+
+            DocumentDbProvider.Configure(config);
+            var toggle = new TestFeatureToggle();
+            // Act and Assert
+            Should.Throw<ToggleConfigurationError>(() =>
+            {
+                var toggleValue = toggle.FeatureEnabled;
+            });             
+        }
+
+        [Test]
+        public void FullConfiguration_AutoCreateDbAndCollectionAndAutoCreateToggle_ToggleValueIsFalse()
+        {
+            // Arrange
+            var config = TestConfig.ValidConfig(databaseId, collectionId);
+            config.AutoCreateDatabaseAndCollection = true;
+            config.AutoCreateFeature = true;
+
+            DocumentDbProvider.Configure(config);
+            var toggle = new TestFeatureToggle();            
+            // Act
+            var toggleValue = toggle.FeatureEnabled;
+            // Assert
+            toggleValue.ShouldBeFalse();
+        }
+
+        [Test]
+        public async Task FullConfiguration_AutoCreateDbAndCollectionAndToggleIsTurnedOn_ToggleValueIsTrue()
+        {
+            // Arrange
+            var config = TestConfig.ValidConfig(databaseId, collectionId);
+            config.AutoCreateDatabaseAndCollection = true;
+            config.AutoCreateFeature = true;
+
+            DocumentDbProvider.Configure(config);
+            var toggle = new TestFeatureToggle();
+
+            var unused = toggle.FeatureEnabled; // Auto creates the database and collection
+            var document = new BooleanFeatureToggleDocument(nameof(TestFeatureToggle)) { Enabled = true };
+            await client.UpsertDocumentAsync(UriFactory.CreateDocumentCollectionUri(databaseId, collectionId), document, disableAutomaticIdGeneration: true);
+            // Act
+            var toggleValue = toggle.FeatureEnabled;
+            // Assert
+            toggleValue.ShouldBeTrue();
+        }
+
+        // create test for the date time feature toggle
     }
 }

--- a/test/FeatureToggle.Azure.DocumentDB.Test/DocumentDbProviderTest.cs
+++ b/test/FeatureToggle.Azure.DocumentDB.Test/DocumentDbProviderTest.cs
@@ -1,0 +1,38 @@
+using FeatureToggle.Azure.Providers;
+using FeatureToggle.Azure.Toggles;
+using Microsoft.Azure.Documents.Client;
+using Moq;
+using Shouldly;
+using System;
+using Xunit;
+
+namespace FeatureToggle.Azure.Test
+{
+    public class DocumentDbProviderTest
+    {
+        class TestableProvider : DocumentDbProvider
+        {
+            protected override DocumentClient CreateDocumentClient()
+            {
+                return new Mock<DocumentClient>().Object;
+            }
+        }
+
+        class TestToggle : DocumentDbToggle
+        {
+            public TestToggle()
+            {
+                ToggleValueProvider =  new TestableProvider();
+            }
+        }
+
+        [Fact]
+        public void Test1()
+        {
+            DocumentDbProvider.Configure("someendpont", "someauthkey");
+            var toggle = new TestToggle();
+
+            toggle.FeatureEnabled.ShouldBeTrue();
+        }
+    }
+}

--- a/test/FeatureToggle.Azure.DocumentDB.Test/DocumentDbProviderTest.cs
+++ b/test/FeatureToggle.Azure.DocumentDB.Test/DocumentDbProviderTest.cs
@@ -3,53 +3,22 @@ using Microsoft.Azure.Documents.Client;
 using NUnit.Framework;
 using Shouldly;
 using System;
-using System.Reflection;
 using System.Threading.Tasks;
 
 namespace FeatureToggle.Azure.DocumentDB.Test
 {
+
     [TestFixture]
-    public class DocumentDbProviderTest
-    {
-        private string databaseId;
-        private string collectionId;
-        private DocumentClient client;
+    public class DocumentDbProviderTest : DocumentDbTestFixture
+    {        
         private DocumentDbProvider sut;
 
         [SetUp]
         public void Setup()
         {
-            client = new DocumentClient(new Uri(TestConfig.ValidEndpoint), TestConfig.ValidAuthKey);
             sut = new DocumentDbProvider();
-
-            databaseId = $"FeatureToggle_{Guid.NewGuid()}_Test";
-            collectionId = $"Toggles_{Guid.NewGuid()}_Test";
-
-            ResetCollectionValidationInProvider();
-        }        
-
-        [TearDown]
-        public async Task Cleanup()
-        {
-            try
-            {
-                await client.DeleteDocumentAsync(UriFactory.CreateDocumentUri("FeatureToggle", "Toggles", nameof(TestFeatureToggle)));
-            }
-            catch { }
-
-            try
-            {
-                await client.DeleteDocumentCollectionAsync(UriFactory.CreateDocumentCollectionUri(databaseId, collectionId));
-            }
-            catch { }
-
-            try
-            {
-                await client.DeleteDatabaseAsync(UriFactory.CreateDatabaseUri(databaseId));
-            }
-            catch { }
-        }        
-
+        }
+        
         [Test]
         public void SimpleConfiguration_ValidEndpointAndAuthKeyToggleDoesNotExist_ThrowsToggleConfigurationError()
         {
@@ -138,14 +107,14 @@ namespace FeatureToggle.Azure.DocumentDB.Test
             AutoCreateToggle();
 
             var document = new BooleanFeatureToggleDocument(nameof(TestFeatureToggle)) { Enabled = true };
-            await client.UpsertDocumentAsync(UriFactory.CreateDocumentCollectionUri(databaseId, collectionId), document, disableAutomaticIdGeneration: true);
+            await UpdateToggleDocument(document);
 
             // Act
             var toggleValue = sut.EvaluateBooleanToggleValue(new TestFeatureToggle());
             // Assert
             toggleValue.ShouldBeTrue();
         }        
-                
+
         [Test]
         public async Task EvaluateDateTimeToggleValue_ToggleExists_ToggleValueIsToday()
         {
@@ -153,36 +122,12 @@ namespace FeatureToggle.Azure.DocumentDB.Test
             AutoCreateToggle();
 
             var document = new DateTimeFeatureToggleDocument(nameof(TestFeatureToggle)) { ToggleTimestamp = DateTime.Today };
-            await client.UpsertDocumentAsync(UriFactory.CreateDocumentCollectionUri(databaseId, collectionId), document, disableAutomaticIdGeneration: true);
+            await UpdateToggleDocument(document);
 
             // Act
             var toggleValue = sut.EvaluateDateTimeToggleValue(new TestFeatureToggle());
             // Assert
             toggleValue.ShouldBe(DateTime.Today);
-        }
-
-        private void AutoCreateToggle()
-        {
-            ConfigureProvider(true, true);
-
-            var toggle = new TestFeatureToggle();
-            var unused = toggle.FeatureEnabled; // Auto creates the database and collection            
-        }
-
-        private void ConfigureProvider(bool autoCreateDbAndCollection = false, bool autoCreateToggle = false)
-        {
-            var config = TestConfig.ValidConfig(databaseId, collectionId);
-            config.AutoCreateDatabaseAndCollection = autoCreateDbAndCollection;
-            config.AutoCreateFeature = autoCreateToggle;
-
-            DocumentDbProvider.Configure(config);
-        }
-
-        private static void ResetCollectionValidationInProvider()
-        {
-            // Reset docdb collection validation in provider
-            var field = typeof(DocumentDbProvider).GetField("_collectionVerified", BindingFlags.Static | BindingFlags.NonPublic);
-            field.SetValue(null, false);
-        }
+        }        
     }
 }

--- a/test/FeatureToggle.Azure.DocumentDB.Test/DocumentDbProviderTest.cs
+++ b/test/FeatureToggle.Azure.DocumentDB.Test/DocumentDbProviderTest.cs
@@ -1,6 +1,5 @@
 using FeatureToggle.Azure.Providers;
 using Microsoft.Azure.Documents.Client;
-using Moq;
 using NUnit.Framework;
 using Shouldly;
 using System;

--- a/test/FeatureToggle.Azure.DocumentDB.Test/DocumentDbTestFixture.cs
+++ b/test/FeatureToggle.Azure.DocumentDB.Test/DocumentDbTestFixture.cs
@@ -1,4 +1,5 @@
-﻿using FeatureToggle.Azure.Providers;
+﻿using FeatureToggle.Azure.DocumentDB.Test.Toggles;
+using FeatureToggle.Azure.Providers;
 using Microsoft.Azure.Documents.Client;
 using NUnit.Framework;
 using System;
@@ -36,6 +37,18 @@ namespace FeatureToggle.Azure.DocumentDB.Test
 
             try
             {
+                await client.DeleteDocumentAsync(UriFactory.CreateDocumentUri("FeatureToggle", "Toggles", nameof(ComingSoonTestFeatureToggle)));
+            }
+            catch { }
+
+            try
+            {
+                await client.DeleteDocumentAsync(UriFactory.CreateDocumentUri("FeatureToggle", "Toggles", nameof(ExpiringTestFeatureToggle)));
+            }
+            catch { }
+
+            try
+            {
                 await client.DeleteDocumentCollectionAsync(UriFactory.CreateDocumentCollectionUri(databaseId, collectionId));
             }
             catch { }
@@ -47,11 +60,11 @@ namespace FeatureToggle.Azure.DocumentDB.Test
             catch { }
         }
 
-        protected void AutoCreateToggle()
+        protected void AutoCreateToggle<T>() where T : IFeatureToggle, new()
         {
             ConfigureProvider(true, true);
 
-            var toggle = new TestFeatureToggle();
+            var toggle = new T();
             var unused = toggle.FeatureEnabled; // Auto creates the database and collection            
         }
 

--- a/test/FeatureToggle.Azure.DocumentDB.Test/DocumentDbTestFixture.cs
+++ b/test/FeatureToggle.Azure.DocumentDB.Test/DocumentDbTestFixture.cs
@@ -1,0 +1,79 @@
+﻿using FeatureToggle.Azure.Providers;
+using Microsoft.Azure.Documents.Client;
+using NUnit.Framework;
+using System;
+using System.Reflection;
+using System.Threading.Tasks;
+
+namespace FeatureToggle.Azure.DocumentDB.Test
+{
+    [TestFixture]
+    public abstract class DocumentDbTestFixture
+    {
+        private string databaseId;
+        private string collectionId;
+        private DocumentClient client;
+
+        [SetUp]
+        public void FixtureSetup()
+        {
+            client = new DocumentClient(new Uri(TestConfig.ValidEndpoint), TestConfig.ValidAuthKey);            
+
+            databaseId = $"FeatureToggle_{Guid.NewGuid()}_Test";
+            collectionId = $"Toggles_{Guid.NewGuid()}_Test";
+
+            ResetCollectionValidationInProvider();
+        }
+
+        [TearDown]
+        public async Task Cleanup()
+        {
+            try
+            {
+                await client.DeleteDocumentAsync(UriFactory.CreateDocumentUri("FeatureToggle", "Toggles", nameof(TestFeatureToggle)));
+            }
+            catch { }
+
+            try
+            {
+                await client.DeleteDocumentCollectionAsync(UriFactory.CreateDocumentCollectionUri(databaseId, collectionId));
+            }
+            catch { }
+
+            try
+            {
+                await client.DeleteDatabaseAsync(UriFactory.CreateDatabaseUri(databaseId));
+            }
+            catch { }
+        }
+
+        protected void AutoCreateToggle()
+        {
+            ConfigureProvider(true, true);
+
+            var toggle = new TestFeatureToggle();
+            var unused = toggle.FeatureEnabled; // Auto creates the database and collection            
+        }
+
+        protected void ConfigureProvider(bool autoCreateDbAndCollection = false, bool autoCreateToggle = false)
+        {
+            var config = TestConfig.ValidConfig(databaseId, collectionId);
+            config.AutoCreateDatabaseAndCollection = autoCreateDbAndCollection;
+            config.AutoCreateFeature = autoCreateToggle;
+
+            DocumentDbProvider.Configure(config);
+        }
+
+        protected async Task UpdateToggleDocument(object document)
+        {
+            await client.UpsertDocumentAsync(UriFactory.CreateDocumentCollectionUri(databaseId, collectionId), document, disableAutomaticIdGeneration: true);
+        }
+
+        protected static void ResetCollectionValidationInProvider()
+        {
+            // Reset docdb collection validation in provider
+            var field = typeof(DocumentDbProvider).GetField("_collectionVerified", BindingFlags.Static | BindingFlags.NonPublic);
+            field.SetValue(null, false);
+        }
+    }
+}

--- a/test/FeatureToggle.Azure.DocumentDB.Test/DocumentDbToggleTest.cs
+++ b/test/FeatureToggle.Azure.DocumentDB.Test/DocumentDbToggleTest.cs
@@ -1,4 +1,5 @@
-﻿using FeatureToggle.Azure.Providers;
+﻿using FeatureToggle.Azure.DocumentDB.Test.Toggles;
+using FeatureToggle.Azure.Providers;
 using NUnit.Framework;
 using Shouldly;
 using System;
@@ -15,7 +16,7 @@ namespace FeatureToggle.Azure.DocumentDB.Test
         public void FeatureEnabled_ToggleExists_ToggleValueIsFalse()
         {
             // Arrange
-            AutoCreateToggle();
+            AutoCreateToggle<TestFeatureToggle>();
             var toggle = new TestFeatureToggle();
             // Act
             var toggleValue = toggle.FeatureEnabled;
@@ -27,7 +28,7 @@ namespace FeatureToggle.Azure.DocumentDB.Test
         public async Task FeatureEnabled_ToggleExists_ToggleValueIsTrue()
         {
             // Arrange
-            AutoCreateToggle();            
+            AutoCreateToggle<TestFeatureToggle>();
             await UpdateToggleDocument(new BooleanFeatureToggleDocument(nameof(TestFeatureToggle)) { Enabled = true });
 
             var toggle = new TestFeatureToggle();

--- a/test/FeatureToggle.Azure.DocumentDB.Test/DocumentDbToggleTest.cs
+++ b/test/FeatureToggle.Azure.DocumentDB.Test/DocumentDbToggleTest.cs
@@ -1,0 +1,40 @@
+﻿using FeatureToggle.Azure.Providers;
+using NUnit.Framework;
+using Shouldly;
+using System;
+using System.Collections.Generic;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace FeatureToggle.Azure.DocumentDB.Test
+{
+    [TestFixture]
+    public class DocumentDbToggleTest : DocumentDbTestFixture
+    {
+        [Test]
+        public void FeatureEnabled_ToggleExists_ToggleValueIsFalse()
+        {
+            // Arrange
+            AutoCreateToggle();
+            var toggle = new TestFeatureToggle();
+            // Act
+            var toggleValue = toggle.FeatureEnabled;
+            // Assert
+            toggleValue.ShouldBeFalse();
+        }
+
+        [Test]
+        public async Task FeatureEnabled_ToggleExists_ToggleValueIsTrue()
+        {
+            // Arrange
+            AutoCreateToggle();            
+            await UpdateToggleDocument(new BooleanFeatureToggleDocument(nameof(TestFeatureToggle)) { Enabled = true });
+
+            var toggle = new TestFeatureToggle();
+            // Act
+            var toggleValue = toggle.FeatureEnabled;
+            // Assert
+            toggleValue.ShouldBeTrue();
+        }
+    }
+}

--- a/test/FeatureToggle.Azure.DocumentDB.Test/FeatureToggle.Azure.DocumentDB.Test.csproj
+++ b/test/FeatureToggle.Azure.DocumentDB.Test/FeatureToggle.Azure.DocumentDB.Test.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp2.0</TargetFramework>
+    <TargetFramework>netcoreapp2.1</TargetFramework>
 
     <IsPackable>false</IsPackable>
   </PropertyGroup>

--- a/test/FeatureToggle.Azure.DocumentDB.Test/FeatureToggle.Azure.DocumentDB.Test.csproj
+++ b/test/FeatureToggle.Azure.DocumentDB.Test/FeatureToggle.Azure.DocumentDB.Test.csproj
@@ -9,9 +9,9 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.7.2" />
     <PackageReference Include="Moq" Version="4.9.0" />
+    <PackageReference Include="NUnit" Version="3.10.1" />
+    <PackageReference Include="NUnit3TestAdapter" Version="3.10.0" />
     <PackageReference Include="Shouldly" Version="3.0.0" />
-    <PackageReference Include="xunit" Version="2.4.0" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.0" />
     <DotNetCliToolReference Include="dotnet-xunit" Version="2.3.1" />
   </ItemGroup>
 

--- a/test/FeatureToggle.Azure.DocumentDB.Test/FeatureToggle.Azure.DocumentDB.Test.csproj
+++ b/test/FeatureToggle.Azure.DocumentDB.Test/FeatureToggle.Azure.DocumentDB.Test.csproj
@@ -7,6 +7,7 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="FeatureToggle" Version="4.0.2" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.8.0" />
     <PackageReference Include="NUnit" Version="3.10.1" />
     <PackageReference Include="NUnit3TestAdapter" Version="3.10.0" />

--- a/test/FeatureToggle.Azure.DocumentDB.Test/FeatureToggle.Azure.DocumentDB.Test.csproj
+++ b/test/FeatureToggle.Azure.DocumentDB.Test/FeatureToggle.Azure.DocumentDB.Test.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <TargetFramework>netcoreapp2.0</TargetFramework>
@@ -7,12 +7,10 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.7.2" />
-    <PackageReference Include="Moq" Version="4.9.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.8.0" />
     <PackageReference Include="NUnit" Version="3.10.1" />
     <PackageReference Include="NUnit3TestAdapter" Version="3.10.0" />
-    <PackageReference Include="Shouldly" Version="3.0.0" />
-    <DotNetCliToolReference Include="dotnet-xunit" Version="2.3.1" />
+    <PackageReference Include="Shouldly" Version="3.0.0" />    
   </ItemGroup>
 
   <ItemGroup>

--- a/test/FeatureToggle.Azure.DocumentDB.Test/FeatureToggle.Azure.DocumentDB.Test.csproj
+++ b/test/FeatureToggle.Azure.DocumentDB.Test/FeatureToggle.Azure.DocumentDB.Test.csproj
@@ -1,0 +1,22 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>netcoreapp2.0</TargetFramework>
+
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.7.2" />
+    <PackageReference Include="Moq" Version="4.9.0" />
+    <PackageReference Include="Shouldly" Version="3.0.0" />
+    <PackageReference Include="xunit" Version="2.4.0" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.0" />
+    <DotNetCliToolReference Include="dotnet-xunit" Version="2.3.1" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\src\FeatureToggle.Azure.DocumentDB\FeatureToggle.Azure.DocumentDB.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/test/FeatureToggle.Azure.DocumentDB.Test/TestConfig.cs
+++ b/test/FeatureToggle.Azure.DocumentDB.Test/TestConfig.cs
@@ -1,0 +1,21 @@
+﻿using FeatureToggle.Azure.Providers;
+
+namespace FeatureToggle.Azure.DocumentDB.Test
+{
+    public static class TestConfig
+    {
+        public const string ValidEndpoint = "https://localhost:8081";
+        public const string ValidAuthKey = "C2y6yDjf5/R+ob0N8A7Cgv30VRDJIWEHLM+4QDU5DE2nQ9nDuVTqobD4b8mGGyPMbIZnqyMsEcaGQy67XIw/Jw==";        
+
+        public static DocumentDbConfiguration ValidConfig(string databaseId, string collectionId)
+        {
+            return new DocumentDbConfiguration
+            {
+                ServiceEndpoint = ValidEndpoint,
+                AuthKey = ValidAuthKey,
+                DatabaseId = databaseId,
+                CollectionId = collectionId
+            };
+        }
+    }
+}

--- a/test/FeatureToggle.Azure.DocumentDB.Test/TestFeatureToggle.cs
+++ b/test/FeatureToggle.Azure.DocumentDB.Test/TestFeatureToggle.cs
@@ -1,0 +1,8 @@
+﻿using FeatureToggle.Azure.Toggles;
+
+namespace FeatureToggle.Azure.DocumentDB.Test
+{    
+    public class TestFeatureToggle : DocumentDbToggle
+    {            
+    }    
+}

--- a/test/FeatureToggle.Azure.DocumentDB.Test/Toggles/ComingSoonTestFeatureToggle.cs
+++ b/test/FeatureToggle.Azure.DocumentDB.Test/Toggles/ComingSoonTestFeatureToggle.cs
@@ -1,0 +1,12 @@
+﻿using FeatureToggle.Azure.Providers;
+
+namespace FeatureToggle.Azure.DocumentDB.Test.Toggles
+{
+    public class ComingSoonTestFeatureToggle : EnabledOnOrAfterDateFeatureToggle
+    {
+        public ComingSoonTestFeatureToggle()
+        {
+            this.ToggleValueProvider = new DocumentDbProvider();
+        }
+    }
+}

--- a/test/FeatureToggle.Azure.DocumentDB.Test/Toggles/ExpiringTestFeatureToggle.cs
+++ b/test/FeatureToggle.Azure.DocumentDB.Test/Toggles/ExpiringTestFeatureToggle.cs
@@ -1,0 +1,12 @@
+﻿using FeatureToggle.Azure.Providers;
+
+namespace FeatureToggle.Azure.DocumentDB.Test.Toggles
+{
+    public class ExpiringTestFeatureToggle : EnabledOnOrBeforeDateFeatureToggle
+    {
+        public ExpiringTestFeatureToggle()
+        {
+            this.ToggleValueProvider = new DocumentDbProvider();
+        }
+    }
+}

--- a/test/FeatureToggle.Azure.DocumentDB.Test/Toggles/TestFeatureToggle.cs
+++ b/test/FeatureToggle.Azure.DocumentDB.Test/Toggles/TestFeatureToggle.cs
@@ -1,6 +1,6 @@
 ﻿using FeatureToggle.Azure.Toggles;
 
-namespace FeatureToggle.Azure.DocumentDB.Test
+namespace FeatureToggle.Azure.DocumentDB.Test.Toggles
 {    
     public class TestFeatureToggle : DocumentDbToggle
     {            

--- a/test/FeatureToggle.Azure.TableStorage.Test/DateTimeToggleTest.cs
+++ b/test/FeatureToggle.Azure.TableStorage.Test/DateTimeToggleTest.cs
@@ -1,0 +1,71 @@
+﻿using FeatureToggle.Azure.Providers;
+using FeatureToggle.Azure.TableStorage.Test.Toggles;
+using NUnit.Framework;
+using Shouldly;
+using System;
+using System.Collections.Generic;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace FeatureToggle.Azure.TableStorage.Test
+{
+    [TestFixture]
+    public class DateTimeToggleTest : TableStorageTestFixture
+    {
+        [Test]
+        public async Task FeatureEnabled_ExpiringFeatureToggleSetToExpireYesterday_ToggleValueIsFalse()
+        {
+            // Arrange
+            AutoCreateToggle<ExpiringTestFeatureToggle>();
+            await UpdateToggleEntity(new DateTimeFeatureToggleEntity(partitionKey, nameof(ExpiringTestFeatureToggle)) { ToggleTimestamp = DateTime.Now.AddDays(-1) });
+
+            var toggle = new ExpiringTestFeatureToggle();
+            // Act
+            var toggleValue = toggle.FeatureEnabled;
+            // Assert
+            toggleValue.ShouldBeFalse();
+        }
+
+        [Test]
+        public async Task FeatureEnabled_ExpiringFeatureToggleSetToExpireTomorrow_ToggleValueIsTrue()
+        {
+            // Arrange            
+            AutoCreateToggle<ExpiringTestFeatureToggle>();
+            await UpdateToggleEntity(new DateTimeFeatureToggleEntity(partitionKey, nameof(ExpiringTestFeatureToggle)) { ToggleTimestamp = DateTime.Now.AddDays(1) });
+
+            var toggle = new ExpiringTestFeatureToggle();
+            // Act
+            var toggleValue = toggle.FeatureEnabled;
+            // Assert
+            toggleValue.ShouldBeTrue();
+        }
+
+        [Test]
+        public async Task FeatureEnabled_CominSoonFeatureToggleSetToEnabledYesterday_ToggleValueIsTrue()
+        {
+            // Arrange
+            AutoCreateToggle<ComingSoonTestFeatureToggle>();
+            await UpdateToggleEntity(new DateTimeFeatureToggleEntity(partitionKey, nameof(ComingSoonTestFeatureToggle)) { ToggleTimestamp = DateTime.Now.AddDays(-1) });
+
+            var toggle = new ComingSoonTestFeatureToggle();
+            // Act
+            var toggleValue = toggle.FeatureEnabled;
+            // Assert
+            toggleValue.ShouldBeTrue();
+        }
+
+        [Test]
+        public async Task FeatureEnabled_ComingSoonFeatureToggleSetToEnabledTomorrow_ToggleValueIsFalse()
+        {
+            // Arrange
+            AutoCreateToggle<ComingSoonTestFeatureToggle>();
+            await UpdateToggleEntity(new DateTimeFeatureToggleEntity(partitionKey, nameof(ComingSoonTestFeatureToggle)) { ToggleTimestamp = DateTime.Now.AddDays(1) });
+
+            var toggle = new ComingSoonTestFeatureToggle();
+            // Act
+            var toggleValue = toggle.FeatureEnabled;
+            // Assert
+            toggleValue.ShouldBeFalse();
+        }
+    }
+}

--- a/test/FeatureToggle.Azure.TableStorage.Test/FeatureToggle.Azure.TableStorage.Test.csproj
+++ b/test/FeatureToggle.Azure.TableStorage.Test/FeatureToggle.Azure.TableStorage.Test.csproj
@@ -1,0 +1,21 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>netcoreapp2.1</TargetFramework>
+
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="FeatureToggle" Version="4.0.2" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.8.0" />
+    <PackageReference Include="NUnit" Version="3.10.1" />
+    <PackageReference Include="NUnit3TestAdapter" Version="3.10.0" />
+    <PackageReference Include="Shouldly" Version="3.0.0" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\src\FeatureToggle.Azure.TableStorage\FeatureToggle.Azure.TableStorage.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/test/FeatureToggle.Azure.TableStorage.Test/TableStorageProviderTest.cs
+++ b/test/FeatureToggle.Azure.TableStorage.Test/TableStorageProviderTest.cs
@@ -1,0 +1,123 @@
+using FeatureToggle.Azure.Providers;
+using FeatureToggle.Azure.TableStorage.Test.Toggles;
+using NUnit.Framework;
+using Shouldly;
+using System;
+using System.Threading.Tasks;
+
+namespace FeatureToggle.Azure.TableStorage.Test
+{
+
+    [TestFixture]
+    public class TableStorageProviderTest : TableStorageTestFixture
+    {        
+        private TableStorageProvider sut;
+
+        [SetUp]
+        public void Setup()
+        {
+            sut = new TableStorageProvider();
+        }
+        
+        [Test]
+        public void SimpleConfiguration_ValidConnectionStringToggleDoesNotExist_ThrowsToggleConfigurationError()
+        {
+            // Arrange
+            TableStorageProvider.Configure(TestConfig.ValidConnectionString);
+            
+            // Act and Assert
+            Should.Throw<ToggleConfigurationError>(() =>
+            {
+                var toggleValue = sut.EvaluateBooleanToggleValue(new TestFeatureToggle());
+            });
+        }
+
+        [Test]
+        public void SimpleConfiguration_ConnectionStringIsNull_ThrowsArgumentException()
+        {   
+            // Act and Assert
+            Should.Throw<ArgumentException>(() =>
+            {
+                TableStorageProvider.Configure((string) null);
+            });
+        }        
+
+        [Test]
+        public void FullConfiguration_ConfigIsNull_ThrowsAgurmentNullException()
+        {
+            // Act and Assert
+            Should.Throw<ArgumentNullException>(() =>
+            {
+                TableStorageProvider.Configure((TableStorageConfiguration) null);
+            });
+        }
+
+        [Test]
+        public void EvaluateBooleanToggleValue_AutoCreateTableToggleDoesNotExist_ThrowsToggleConfigurationError()
+        {
+            // Arrange
+            ConfigureProvider(autoCreateTable: true);
+
+            // Act and Assert
+            Should.Throw<ToggleConfigurationError>(() =>
+            {
+                var toggleValue = sut.EvaluateBooleanToggleValue(new TestFeatureToggle());
+            });
+        }
+
+        [Test]
+        public void EvaluateBooleanToggleValue_AutoCreateToggleTableDoesNotExist_ThrowsToggleConfigurationError()
+        {
+            // Arrange
+            ConfigureProvider(autoCreateToggle: true);
+
+            // Act and Assert
+            Should.Throw<ToggleConfigurationError>(() =>
+            {
+                var toggleValue = sut.EvaluateBooleanToggleValue(new TestFeatureToggle());
+            });             
+        }
+
+        [Test]
+        public void EvaluateBooleanToggleValue_AutoCreateTableAndAutoCreateToggle_ToggleValueIsFalse()
+        {
+            // Arrange
+            ConfigureProvider(true, true);
+
+            // Act
+            var toggleValue = sut.EvaluateBooleanToggleValue(new TestFeatureToggle());
+            // Assert
+            toggleValue.ShouldBeFalse();
+        }
+
+        [Test]
+        public async Task EvaluateBooleanToggleValue_ToggleExists_ToggleValueIsTrue()
+        {
+            // Arrange
+            AutoCreateToggle<TestFeatureToggle>();
+
+            var entity = new BooleanFeatureToggleEntity(partitionKey, nameof(TestFeatureToggle)) { Enabled = true };
+            await UpdateToggleEntity(entity);
+
+            // Act
+            var toggleValue = sut.EvaluateBooleanToggleValue(new TestFeatureToggle());
+            // Assert
+            toggleValue.ShouldBeTrue();
+        }        
+
+        [Test]
+        public async Task EvaluateDateTimeToggleValue_ToggleExists_ToggleValueIsUtcNow()
+        {
+            // Arrange
+            AutoCreateToggle<TestFeatureToggle>();
+            var utcNow = DateTime.UtcNow;
+            var entity = new DateTimeFeatureToggleEntity(partitionKey, nameof(TestFeatureToggle)) { ToggleTimestamp = utcNow };
+            await UpdateToggleEntity(entity);
+
+            // Act
+            var toggleValue = sut.EvaluateDateTimeToggleValue(new TestFeatureToggle());
+            // Assert
+            toggleValue.ShouldBe(utcNow);
+        }        
+    }
+}

--- a/test/FeatureToggle.Azure.TableStorage.Test/TableStorageTestFixture.cs
+++ b/test/FeatureToggle.Azure.TableStorage.Test/TableStorageTestFixture.cs
@@ -1,0 +1,72 @@
+﻿using FeatureToggle.Azure.Providers;
+using FeatureToggle.Azure.TableStorage.Test.Toggles;
+using Microsoft.WindowsAzure.Storage;
+using Microsoft.WindowsAzure.Storage.Table;
+using NUnit.Framework;
+using System;
+using System.Reflection;
+using System.Threading.Tasks;
+
+namespace FeatureToggle.Azure.TableStorage.Test
+{
+    [TestFixture]
+    public abstract class TableStorageTestFixture
+    {
+        private string tableName;
+        private CloudTable table;
+        private CloudTableClient tableClient;
+        protected string partitionKey;
+
+        [SetUp]
+        public void FixtureSetup()
+        {
+            tableName = $"TestFeatureToggles{Guid.NewGuid().ToString().Replace("-", string.Empty)}";
+            partitionKey = typeof(TestFeatureToggle).Assembly.GetName().Name;
+
+            var storageAccount = CloudStorageAccount.Parse("UseDevelopmentStorage=true");
+            tableClient = storageAccount.CreateCloudTableClient();
+            table = tableClient.GetTableReference(tableName);
+
+            ResetTableValidationInProvider();
+        }
+
+        [TearDown]
+        public async Task Cleanup()
+        {
+            var x = await table.DeleteIfExistsAsync();
+
+            var defaultTable = tableClient.GetTableReference(new TableStorageConfiguration().TableName);
+            var z = await defaultTable.DeleteIfExistsAsync();
+        }
+
+        protected void AutoCreateToggle<T>() where T : IFeatureToggle, new()
+        {
+            ConfigureProvider(true, true);
+
+            var toggle = new T();
+            var unused = toggle.FeatureEnabled; // Auto creates the database and collection            
+        }
+
+        protected void ConfigureProvider(bool autoCreateTable = false, bool autoCreateToggle = false)
+        {
+            var config = new TableStorageConfiguration { ConnectionString = "UseDevelopmentStorage=true" };
+            config.AutoCreateTable = autoCreateTable;
+            config.AutoCreateFeature = autoCreateToggle;
+            config.TableName = tableName;
+
+            TableStorageProvider.Configure(config);
+        }
+
+        protected async Task UpdateToggleEntity(ITableEntity entity)
+        {            
+            var result = await table.ExecuteAsync(TableOperation.InsertOrMerge(entity));
+        }
+
+        protected static void ResetTableValidationInProvider()
+        {
+            // Reset docdb collection validation in provider
+            var field = typeof(TableStorageProvider).GetField("_tableVerified", BindingFlags.Static | BindingFlags.NonPublic);
+            field.SetValue(null, false);
+        }
+    }
+}

--- a/test/FeatureToggle.Azure.TableStorage.Test/TableStorageToggleTest.cs
+++ b/test/FeatureToggle.Azure.TableStorage.Test/TableStorageToggleTest.cs
@@ -1,0 +1,44 @@
+﻿using FeatureToggle.Azure.Providers;
+using FeatureToggle.Azure.TableStorage.Test.Toggles;
+using Microsoft.WindowsAzure.Storage;
+using Microsoft.WindowsAzure.Storage.Table;
+using NUnit.Framework;
+using Shouldly;
+using System;
+using System.Collections.Generic;
+using System.Reflection;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace FeatureToggle.Azure.TableStorage.Test
+{
+    [TestFixture]
+    public class TableStorageToggleTest : TableStorageTestFixture
+    {      
+        [Test]
+        public void FeatureEnabled_ToggleExists_ToggleValueIsFalse()
+        {
+            // Arrange
+            AutoCreateToggle<TestFeatureToggle>();
+            var toggle = new TestFeatureToggle();
+            // Act
+            var toggleValue = toggle.FeatureEnabled;
+            // Assert
+            toggleValue.ShouldBeFalse();
+        }
+
+        [Test]
+        public async Task FeatureEnabled_ToggleExists_ToggleValueIsTrue()
+        {
+            // Arrange
+            AutoCreateToggle<TestFeatureToggle>();
+            await UpdateToggleEntity(new BooleanFeatureToggleEntity(partitionKey, nameof(TestFeatureToggle)) { Enabled = true });
+
+            var toggle = new TestFeatureToggle();
+            // Act
+            var toggleValue = toggle.FeatureEnabled;
+            // Assert
+            toggleValue.ShouldBeTrue();
+        }        
+    }
+}

--- a/test/FeatureToggle.Azure.TableStorage.Test/TestConfig.cs
+++ b/test/FeatureToggle.Azure.TableStorage.Test/TestConfig.cs
@@ -1,0 +1,17 @@
+﻿using FeatureToggle.Azure.Providers;
+
+namespace FeatureToggle.Azure.TableStorage.Test
+{
+    public static class TestConfig
+    {
+        public const string ValidConnectionString = "UseDevelopmentStorage=true";        
+
+        public static TableStorageConfiguration ValidConfig(string connectionString)
+        {
+            return new TableStorageConfiguration
+            {
+                ConnectionString = connectionString
+            };
+        }
+    }
+}

--- a/test/FeatureToggle.Azure.TableStorage.Test/Toggles/ComingSoonTestFeatureToggle.cs
+++ b/test/FeatureToggle.Azure.TableStorage.Test/Toggles/ComingSoonTestFeatureToggle.cs
@@ -1,0 +1,12 @@
+﻿using FeatureToggle.Azure.Providers;
+
+namespace FeatureToggle.Azure.TableStorage.Test.Toggles
+{
+    public class ComingSoonTestFeatureToggle : EnabledOnOrAfterDateFeatureToggle
+    {
+        public ComingSoonTestFeatureToggle()
+        {
+            this.ToggleValueProvider = new TableStorageProvider();
+        }
+    }
+}

--- a/test/FeatureToggle.Azure.TableStorage.Test/Toggles/ExpiringTestFeatureToggle.cs
+++ b/test/FeatureToggle.Azure.TableStorage.Test/Toggles/ExpiringTestFeatureToggle.cs
@@ -1,0 +1,12 @@
+﻿using FeatureToggle.Azure.Providers;
+
+namespace FeatureToggle.Azure.TableStorage.Test.Toggles
+{
+    public class ExpiringTestFeatureToggle : EnabledOnOrBeforeDateFeatureToggle
+    {
+        public ExpiringTestFeatureToggle()
+        {
+            this.ToggleValueProvider = new TableStorageProvider();
+        }
+    }
+}

--- a/test/FeatureToggle.Azure.TableStorage.Test/Toggles/TestFeatureToggle.cs
+++ b/test/FeatureToggle.Azure.TableStorage.Test/Toggles/TestFeatureToggle.cs
@@ -1,0 +1,8 @@
+﻿using FeatureToggle.Azure.Toggles;
+
+namespace FeatureToggle.Azure.TableStorage.Test.Toggles
+{    
+    public class TestFeatureToggle : TableStorageToggle
+    {            
+    }    
+}


### PR DESCRIPTION
Doc Db and Table Storage providers now have proper unit tests, or actually integration tests, since the underlying storage is not mocked, but requires the emulators to be running locally.