### PR TITLE
Unit tests of SF provider

### DIFF
--- a/FeatureToggle.Azure.sln
+++ b/FeatureToggle.Azure.sln
@@ -17,7 +17,9 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "TableStorage", "TableStorag
 EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "ServiceFabric", "ServiceFabric", "{E8D38200-46E2-4434-82E2-DD86644B78A1}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "FeatureToggle.Azure.TableStorage.Test", "test\FeatureToggle.Azure.TableStorage.Test\FeatureToggle.Azure.TableStorage.Test.csproj", "{00F46000-D1C8-4900-8EB5-63A89EDCAA12}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "FeatureToggle.Azure.TableStorage.Test", "test\FeatureToggle.Azure.TableStorage.Test\FeatureToggle.Azure.TableStorage.Test.csproj", "{00F46000-D1C8-4900-8EB5-63A89EDCAA12}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "FeatureToggle.Azure.ServiceFabric.Test", "test\FeatureToggle.Azure.ServiceFabric.Test\FeatureToggle.Azure.ServiceFabric.Test.csproj", "{52B50278-82E0-4B97-B83E-71AA80E942B9}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -45,6 +47,10 @@ Global
 		{00F46000-D1C8-4900-8EB5-63A89EDCAA12}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{00F46000-D1C8-4900-8EB5-63A89EDCAA12}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{00F46000-D1C8-4900-8EB5-63A89EDCAA12}.Release|Any CPU.Build.0 = Release|Any CPU
+		{52B50278-82E0-4B97-B83E-71AA80E942B9}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{52B50278-82E0-4B97-B83E-71AA80E942B9}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{52B50278-82E0-4B97-B83E-71AA80E942B9}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{52B50278-82E0-4B97-B83E-71AA80E942B9}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -55,6 +61,7 @@ Global
 		{1CDF4589-A0B2-4B15-AD70-D83DD489F055} = {E8D38200-46E2-4434-82E2-DD86644B78A1}
 		{9AF9253E-C558-44C1-8883-10C353F55A51} = {CB1A56C2-DD8C-4C7F-99DA-895BBA967FC6}
 		{00F46000-D1C8-4900-8EB5-63A89EDCAA12} = {01199EBA-AB76-44E1-AFBE-B1E36BF788C7}
+		{52B50278-82E0-4B97-B83E-71AA80E942B9} = {E8D38200-46E2-4434-82E2-DD86644B78A1}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {F39C8383-A0E2-4F37-BC1F-7A23D75A57DD}

--- a/test/FeatureToggle.Azure.ServiceFabric.Test/DateTimeToggleTest.cs
+++ b/test/FeatureToggle.Azure.ServiceFabric.Test/DateTimeToggleTest.cs
@@ -1,0 +1,89 @@
+﻿using FeatureToggle.Azure.Providers;
+using FeatureToggle.Azure.ServiceFabric.Test.Toggles;
+using NUnit.Framework;
+using Shouldly;
+using System;
+using System.Collections.Generic;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace FeatureToggle.Azure.ServiceFabric.Test
+{
+
+    [TestFixture]
+    public class DateTimeToggleTest : ServiceFabricTestFixture
+    {
+        private const string ExpectedDateFormat = @"dd-MMM-yyyy HH:mm:ss";
+
+        [SetUp]
+        public void Setup()
+        {
+            ServiceFabricConfigProvider.Configure(usePrefix: false);
+        }
+
+        [Test]
+        public void FeatureEnabled_ExpiringFeatureToggleSetToExpireYesterday_ToggleValueIsFalse()
+        {
+            // Arrange
+            SetToggleInConfig(nameof(ExpiringTestFeatureToggle), DateTime.Today.AddDays(-1).ToString(ExpectedDateFormat));
+            var toggle = new ExpiringTestFeatureToggle();
+            // Act
+            var toggleValue = toggle.FeatureEnabled;
+            // Assert
+            toggleValue.ShouldBeFalse();
+        }
+
+        [Test]
+        public void FeatureEnabled_ExpiringFeatureToggleSetToExpireTomorrow_ToggleValueIsTrue()
+        {
+            // Arrange            
+            SetToggleInConfig(nameof(ExpiringTestFeatureToggle), DateTime.Today.AddDays(1).ToString(ExpectedDateFormat));
+            var toggle = new ExpiringTestFeatureToggle();
+            // Act
+            var toggleValue = toggle.FeatureEnabled;
+            // Assert
+            toggleValue.ShouldBeTrue();
+        }
+
+        [Test]
+        public void FeatureEnabled_CominSoonFeatureToggleSetToEnabledYesterday_ToggleValueIsTrue()
+        {
+            // Arrange            
+            SetToggleInConfig(nameof(ComingSoonTestFeatureToggle), DateTime.Today.AddDays(-1).ToString(ExpectedDateFormat));
+            var toggle = new ComingSoonTestFeatureToggle();
+            // Act
+            var toggleValue = toggle.FeatureEnabled;
+            // Assert
+            toggleValue.ShouldBeTrue();
+        }
+
+        [Test]
+        public void FeatureEnabled_ComingSoonFeatureToggleSetToEnabledTomorrow_ToggleValueIsFalse()
+        {
+            // Arrange
+            SetToggleInConfig(nameof(ComingSoonTestFeatureToggle), DateTime.Today.AddDays(1).ToString(ExpectedDateFormat));            
+            var toggle = new ComingSoonTestFeatureToggle();
+            // Act
+            var toggleValue = toggle.FeatureEnabled;
+            // Assert
+            toggleValue.ShouldBeFalse();
+        }
+
+        [Test]
+        public void FeatureEnabled_ComingSoonFeatureToggleSetToInvalidDate_ThrowToggleConfigError()
+        {
+            // Arrange
+            SetToggleInConfig(nameof(ComingSoonTestFeatureToggle), "invalid date string");
+            var toggle = new ComingSoonTestFeatureToggle();
+
+            var error = Should.Throw<ToggleConfigurationError>(() =>
+            {
+                // Act
+                var toggleValue = toggle.FeatureEnabled;
+            });
+
+            // Assert
+            error.Message.ShouldContain("cannot be converted to a DateTime as defined in config key");
+        }
+    }
+}

--- a/test/FeatureToggle.Azure.ServiceFabric.Test/FeatureToggle.Azure.ServiceFabric.Test.csproj
+++ b/test/FeatureToggle.Azure.ServiceFabric.Test/FeatureToggle.Azure.ServiceFabric.Test.csproj
@@ -11,6 +11,7 @@
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.8.0" />
     <PackageReference Include="NUnit" Version="3.10.1" />
     <PackageReference Include="NUnit3TestAdapter" Version="3.10.0" />
+    <PackageReference Include="ServiceFabric.Mocks" Version="3.3.9" />
     <PackageReference Include="Shouldly" Version="3.0.0" />
   </ItemGroup>
 

--- a/test/FeatureToggle.Azure.ServiceFabric.Test/FeatureToggle.Azure.ServiceFabric.Test.csproj
+++ b/test/FeatureToggle.Azure.ServiceFabric.Test/FeatureToggle.Azure.ServiceFabric.Test.csproj
@@ -1,0 +1,21 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>netcoreapp2.1</TargetFramework>
+
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="FeatureToggle" Version="4.0.2" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.8.0" />
+    <PackageReference Include="NUnit" Version="3.10.1" />
+    <PackageReference Include="NUnit3TestAdapter" Version="3.10.0" />
+    <PackageReference Include="Shouldly" Version="3.0.0" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\src\FeatureToggle.Azure.ServiceFabric\FeatureToggle.Azure.ServiceFabric.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/test/FeatureToggle.Azure.ServiceFabric.Test/ServiceFabricConfigProviderTest.cs
+++ b/test/FeatureToggle.Azure.ServiceFabric.Test/ServiceFabricConfigProviderTest.cs
@@ -1,0 +1,46 @@
+﻿using FeatureToggle.Azure.Providers;
+using NUnit.Framework;
+using Shouldly;
+using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace FeatureToggle.Azure.ServiceFabric.Test
+{
+    [TestFixture]
+    public class ServiceFabricConfigProviderTest : ServiceFabricTestFixture
+    {
+        [Test]
+        public void SimpleConfiguration_ConfigPackageNameIsNull_ThrowsArgumentException()
+        {            
+            Should.Throw<ArgumentException>(() => ServiceFabricConfigProvider.Configure(null, "Toggles"));
+        }
+
+        [Test]
+        public void SimpleConfiguration_ConfigSectionNameIsNull_ThrowsArgumentException()
+        {
+            Should.Throw<ArgumentException>(() => ServiceFabricConfigProvider.Configure("Testconfig", null));
+        }
+
+        [Test]
+        public void SimpleConfiguration_SetCustomPackageNameAndSection_ProviderIsConfigured()
+        {            
+            Should.NotThrow(() => ServiceFabricConfigProvider.Configure("Testconfig", "Toggles"));            
+        }
+
+        [Test]
+        public void FullConfiguration_ConfigurationIsNull_ThrowsArgumentNullException()
+        {
+            Should.Throw<ArgumentNullException>(() => ServiceFabricConfigProvider.Configure(null));
+        }
+
+        [Test]
+        public void FullConfiguration_SetCustomPackageNameAndSection_ProviderIsConfigured()
+        {
+            // Arrange
+            var config = new ServiceFabricConfiguration { ConfigPackageName = "TestConfig", ConfigSectionName = "Toggles" };
+            // Act and Assert
+            Should.NotThrow(() => ServiceFabricConfigProvider.Configure(config));
+        }
+    }
+}

--- a/test/FeatureToggle.Azure.ServiceFabric.Test/ServiceFabricFeatureToggleTest.cs
+++ b/test/FeatureToggle.Azure.ServiceFabric.Test/ServiceFabricFeatureToggleTest.cs
@@ -1,0 +1,80 @@
+﻿using FeatureToggle.Azure.Providers;
+using FeatureToggle.Azure.ServiceFabric.Test.Toggles;
+using NUnit.Framework;
+using Shouldly;
+
+namespace FeatureToggle.Azure.ServiceFabric.Test
+{
+    [TestFixture]
+    public class ServiceFabricFeatureToggleTest : ServiceFabricTestFixture
+    {
+        [Test]
+        public void FeatureEnabled_ToggleExists_ToggleValueIsFalse()
+        {
+            // Arrange
+            SetToggleInConfig($"FeatureToggle.{nameof(TestFeatureToggle)}", bool.FalseString);
+            var toggle = new TestFeatureToggle();
+            // Act
+            var toggleValue = toggle.FeatureEnabled;
+            // Assert
+            toggleValue.ShouldBeFalse();
+        }
+
+        [Test]
+        public void FeatureEnabled_ToggleExists_ToggleValueIsTrue()
+        {
+            // Arrange
+            SetToggleInConfig($"FeatureToggle.{nameof(TestFeatureToggle)}", bool.TrueString);            
+            var toggle = new TestFeatureToggle();
+            // Act
+            var toggleValue = toggle.FeatureEnabled;
+            // Assert
+            toggleValue.ShouldBeTrue();
+        }
+
+        [Test, Order(1)]
+        public void FeatureEnabled_ToggleNameIsWithoutPrefixAndNotConfigured_ThrowsToggleConfigurationError()
+        {
+            // Arrange            
+            SetToggleInConfig(nameof(TestFeatureToggle), bool.TrueString);
+            var toggle = new TestFeatureToggle();
+            // Assert            
+            var error = Should.Throw<ToggleConfigurationError>(() =>
+            {
+                // Act
+                var toggleValue = toggle.FeatureEnabled;
+            });
+
+            error.Message.ShouldBe("The key 'FeatureToggle.TestFeatureToggle' was not found in settings.xml");
+        }
+
+        [Test, Order(2)]
+        public void FeatureEnabled_ToggleNameIsWithoutPrefixAndConfigured_ToggleValueIsTrue()
+        {
+            // Arrange            
+            ServiceFabricConfigProvider.Configure(usePrefix: false);
+            SetToggleInConfig(nameof(TestFeatureToggle), bool.TrueString);
+            var toggle = new TestFeatureToggle();
+            // Act
+            var toggleValue = toggle.FeatureEnabled;
+            // Assert
+            toggleValue.ShouldBeTrue();
+        }
+
+        [Test]
+        public void FeatureEnabled_FeatureToggleSetToInvalidValue_ThrowsToggleConfigurationError()
+        {
+            // Arrange            
+            SetToggleInConfig($"FeatureToggle.{nameof(TestFeatureToggle)}", "not a bool value");
+            var toggle = new TestFeatureToggle();
+            // Assert            
+            var error = Should.Throw<ToggleConfigurationError>(() =>
+            {
+                // Act
+                var toggleValue = toggle.FeatureEnabled;
+            });
+
+            error.Message.ShouldContain("cannot be converted to a boolean as defined in config key");
+        }
+    }
+}

--- a/test/FeatureToggle.Azure.ServiceFabric.Test/ServiceFabricTestFixture.cs
+++ b/test/FeatureToggle.Azure.ServiceFabric.Test/ServiceFabricTestFixture.cs
@@ -1,0 +1,22 @@
+﻿using FeatureToggle.Azure.Providers;
+using NUnit.Framework;
+
+namespace FeatureToggle.Azure.ServiceFabric.Test
+{
+    [TestFixture]
+    public abstract class ServiceFabricTestFixture
+    {
+        [SetUp]
+        public void BaseSetup()
+        {
+            ServiceFabricConfigProvider.Configure(new ServiceFabricConfiguration());
+            ServiceFabricConfigProvider.SetCodePackageActivationContextFactory(TestConfig.CreateMockCodePackageActivationContext);
+        }
+
+        protected void SetToggleInConfig(string name, string value)
+        {
+            TestConfig.ToggleName = name;
+            TestConfig.ToggleValue = value;
+        }
+    }
+}

--- a/test/FeatureToggle.Azure.ServiceFabric.Test/TestConfig.cs
+++ b/test/FeatureToggle.Azure.ServiceFabric.Test/TestConfig.cs
@@ -1,0 +1,56 @@
+﻿using FeatureToggle.Azure.Providers;
+using FeatureToggle.Azure.ServiceFabric.Test.Toggles;
+using ServiceFabric.Mocks;
+using System;
+using System.Collections.Generic;
+using System.Fabric;
+using System.Fabric.Description;
+using System.Text;
+using static ServiceFabric.Mocks.MockConfigurationPackage;
+
+namespace FeatureToggle.Azure.ServiceFabric.Test
+{
+    public static class TestConfig
+    {
+        public static string ConfigPackageName { get; set; } = new ServiceFabricConfiguration().ConfigPackageName;
+        public static string ConfigSectionName { get; set; } = new ServiceFabricConfiguration().ConfigSectionName;
+        public static string ToggleName { get; set; } = nameof(TestFeatureToggle);
+        public static string ToggleValue { get; set; } = string.Empty;
+
+        public static ICodePackageActivationContext CreateMockCodePackageActivationContext()
+        {
+            //build ConfigurationSectionCollection
+            var configSections = new ConfigurationSectionCollection();
+
+            //Build ConfigurationSettings
+            var configSettings = CreateConfigurationSettings(configSections);
+
+            //add one ConfigurationSection
+            ConfigurationSection configSection = CreateConfigurationSection(ConfigSectionName);
+            configSections.Add(configSection);
+
+            //add one Parameters entry
+            ConfigurationProperty parameter = CreateConfigurationSectionParameters(ToggleName, ToggleValue);
+            configSection.Parameters.Add(parameter);
+
+            //Build ConfigurationPackage
+            ConfigurationPackage configPackage = CreateConfigurationPackage(configSettings, nameof(configPackage.Path));
+
+            return new MockCodePackageActivationContext(
+                "fabric:/MockApp",
+                "MockAppType",
+                "Code",
+                "1.0.0.0",
+                Guid.NewGuid().ToString(),
+                @"C:\logDirectory",
+                @"C:\tempDirectory",
+                @"C:\workDirectory",
+                "ServiceManifestName",
+                "1.0.0.0")
+            {
+                ConfigurationPackage = configPackage,
+                ConfigurationPackageNames = new List<string> { ConfigPackageName }
+            };
+        }
+    }
+}

--- a/test/FeatureToggle.Azure.ServiceFabric.Test/Toggles/ComingSoonTestFeatureToggle.cs
+++ b/test/FeatureToggle.Azure.ServiceFabric.Test/Toggles/ComingSoonTestFeatureToggle.cs
@@ -1,0 +1,12 @@
+﻿using FeatureToggle.Azure.Providers;
+
+namespace FeatureToggle.Azure.ServiceFabric.Test.Toggles
+{
+    public class ComingSoonTestFeatureToggle : EnabledOnOrAfterDateFeatureToggle
+    {
+        public ComingSoonTestFeatureToggle()
+        {
+            this.ToggleValueProvider = new ServiceFabricConfigProvider();
+        }
+    }
+}

--- a/test/FeatureToggle.Azure.ServiceFabric.Test/Toggles/ExpiringTestFeatureToggle.cs
+++ b/test/FeatureToggle.Azure.ServiceFabric.Test/Toggles/ExpiringTestFeatureToggle.cs
@@ -1,0 +1,12 @@
+﻿using FeatureToggle.Azure.Providers;
+
+namespace FeatureToggle.Azure.ServiceFabric.Test.Toggles
+{
+    public class ExpiringTestFeatureToggle : EnabledOnOrBeforeDateFeatureToggle
+    {
+        public ExpiringTestFeatureToggle()
+        {
+            this.ToggleValueProvider = new ServiceFabricConfigProvider();
+        }
+    }
+}

--- a/test/FeatureToggle.Azure.ServiceFabric.Test/Toggles/TestFeatureToggle.cs
+++ b/test/FeatureToggle.Azure.ServiceFabric.Test/Toggles/TestFeatureToggle.cs
@@ -1,0 +1,8 @@
+﻿using FeatureToggle.Azure.Toggles;
+
+namespace FeatureToggle.Azure.ServiceFabric.Test.Toggles
+{    
+    public class TestFeatureToggle : ServiceFabricToggle
+    {            
+    }    
+}


### PR DESCRIPTION
Added lots of unit tests for ServiceFabric provider using ServiceFabric.Mocks to mock out the SF dependencies. 
Refactored the SF Config provider to be able to set the CodePackageActivationContext from tests, but defaults to use the FabricRuntime as prior implementation did directly.