### PR TITLE
Providers implement ITimePeriodProvider interface

### DIFF
--- a/src/FeatureToggle.Azure.DocumentDB/FeatureToggle.Azure.DocumentDB.csproj
+++ b/src/FeatureToggle.Azure.DocumentDB/FeatureToggle.Azure.DocumentDB.csproj
@@ -9,13 +9,15 @@
     <Copyright>Copyright © 2018</Copyright>
     <RepositoryType>Git</RepositoryType>
     <RepositoryUrl>https://github.com/mikanyg/FeatureToggle.Azure.git</RepositoryUrl>
-    <PackageReleaseNotes>1.1.0
+    <PackageReleaseNotes>1.2.0
+- Provider implements ITimePeriodProvider. Can be used as provider for feature toggles inheriting from FeatureToggle.EnabledBetweenDatesFeatureToggle.
+1.1.0
 - Provider implements IDateTimeToggleValueProvider. Can be used as provider for feature toggles inheriting from FeatureToggle.EnabledOnOrAfterDateFeatureToggle or FeatureToggle.EnabledOnOrBeforeDateFeatureToggle.
 1.0.0
 - Initial release</PackageReleaseNotes>
     <PackageTags>FeatureToggle Toggle Azure DocumentDB DocDB CosmosDB NetStandard</PackageTags>
     <Description>FeatureToggle provider for storing feature toggles in Azure DocumentDB.</Description>
-    <Version>1.1.0</Version>
+    <Version>1.2.0</Version>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/FeatureToggle.Azure.DocumentDB/Providers/DocumentDbProvider.cs
+++ b/src/FeatureToggle.Azure.DocumentDB/Providers/DocumentDbProvider.cs
@@ -46,7 +46,7 @@ namespace FeatureToggle.Azure.Providers
         public Tuple<DateTime, DateTime> EvaluateTimePeriod(IFeatureToggle toggle)
         {
             return EvaluateToggleValue(toggle, 
-                document => new Tuple<DateTime, DateTime>(document.EnabledFrom, document.EnabledTo), 
+                document => new Tuple<DateTime, DateTime>(document.Start, document.End), 
                 toggleName => new TimePeriodFeatureToggleDocument(toggleName));
         }
 

--- a/src/FeatureToggle.Azure.DocumentDB/Providers/DocumentDbProvider.cs
+++ b/src/FeatureToggle.Azure.DocumentDB/Providers/DocumentDbProvider.cs
@@ -7,7 +7,7 @@ using System.Net;
 
 namespace FeatureToggle.Azure.Providers
 {
-    public class DocumentDbProvider : IBooleanToggleValueProvider, IDateTimeToggleValueProvider
+    public class DocumentDbProvider : IBooleanToggleValueProvider, IDateTimeToggleValueProvider, ITimePeriodProvider
     {
         private static bool _collectionVerified;
 
@@ -41,6 +41,13 @@ namespace FeatureToggle.Azure.Providers
         public DateTime EvaluateDateTimeToggleValue(IFeatureToggle toggle)
         {
             return EvaluateToggleValue(toggle, document => document.ToggleTimestamp, toggleName => new DateTimeFeatureToggleDocument(toggleName));
+        }
+
+        public Tuple<DateTime, DateTime> EvaluateTimePeriod(IFeatureToggle toggle)
+        {
+            return EvaluateToggleValue(toggle, 
+                document => new Tuple<DateTime, DateTime>(document.EnabledFrom, document.EnabledTo), 
+                toggleName => new TimePeriodFeatureToggleDocument(toggleName));
         }
 
         private TValue EvaluateToggleValue<TDocument, TValue>(IFeatureToggle toggle, Func<TDocument, TValue> valueSelector, Func<string, TDocument> documentCreator) where TDocument : FeatureToggleDocument

--- a/src/FeatureToggle.Azure.DocumentDB/Providers/TimePeriodFeatureToggleDocument.cs
+++ b/src/FeatureToggle.Azure.DocumentDB/Providers/TimePeriodFeatureToggleDocument.cs
@@ -1,0 +1,18 @@
+﻿using System;
+
+namespace FeatureToggle.Azure.Providers
+{
+    public class TimePeriodFeatureToggleDocument : FeatureToggleDocument
+    {
+        public TimePeriodFeatureToggleDocument() : base() { }
+
+        public TimePeriodFeatureToggleDocument(string toggleName) : base(toggleName)
+        {
+            EnabledFrom = default(DateTime);
+            EnabledTo = default(DateTime);
+        }
+
+        public DateTime EnabledFrom { get; set; }
+        public DateTime EnabledTo { get; set; }
+    }
+}

--- a/src/FeatureToggle.Azure.DocumentDB/Providers/TimePeriodFeatureToggleDocument.cs
+++ b/src/FeatureToggle.Azure.DocumentDB/Providers/TimePeriodFeatureToggleDocument.cs
@@ -8,11 +8,11 @@ namespace FeatureToggle.Azure.Providers
 
         public TimePeriodFeatureToggleDocument(string toggleName) : base(toggleName)
         {
-            EnabledFrom = default(DateTime);
-            EnabledTo = default(DateTime);
+            Start = default(DateTime);
+            End = default(DateTime);
         }
 
-        public DateTime EnabledFrom { get; set; }
-        public DateTime EnabledTo { get; set; }
+        public DateTime Start { get; set; }
+        public DateTime End { get; set; }
     }
 }

--- a/src/FeatureToggle.Azure.ServiceFabric/FeatureToggle.Azure.ServiceFabric.csproj
+++ b/src/FeatureToggle.Azure.ServiceFabric/FeatureToggle.Azure.ServiceFabric.csproj
@@ -9,13 +9,15 @@
     <Copyright>Copyright © 2018</Copyright>
     <RepositoryType>Git</RepositoryType>
     <RepositoryUrl>https://github.com/mikanyg/FeatureToggle.Azure.git</RepositoryUrl>
-    <PackageReleaseNotes>1.1.0
+    <PackageReleaseNotes>1.2.0
+- Provider implements ITimePeriodProvider. Can be used as provider for feature toggles inheriting from FeatureToggle.EnabledBetweenDatesFeatureToggle.
+1.1.0
 - Provider implements IDateTimeToggleValueProvider. Can be used as provider for feature toggles inheriting from FeatureToggle.EnabledOnOrAfterDateFeatureToggle or FeatureToggle.EnabledOnOrBeforeDateFeatureToggle.
 1.0.0
 - Initial release</PackageReleaseNotes>
     <PackageTags>FeatureToggle Toggle Azure ServiceFabric Fabric NetStandard</PackageTags>
     <Description>FeatureToggle provider for storing feature toggles in Service Fabric configuration packages.</Description>
-    <Version>1.1.0</Version>
+    <Version>1.2.0</Version>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/FeatureToggle.Azure.TableStorage/FeatureToggle.Azure.TableStorage.csproj
+++ b/src/FeatureToggle.Azure.TableStorage/FeatureToggle.Azure.TableStorage.csproj
@@ -9,13 +9,15 @@
     <Copyright>Copyright © 2018</Copyright>
     <RepositoryType>Git</RepositoryType>
     <RepositoryUrl>https://github.com/mikanyg/FeatureToggle.Azure.git</RepositoryUrl>
-    <PackageReleaseNotes>1.1.0
+    <PackageReleaseNotes>1.2.0
+- Provider implements ITimePeriodProvider. Can be used as provider for feature toggles inheriting from FeatureToggle.EnabledBetweenDatesFeatureToggle.
+1.1.0
 - Provider implements IDateTimeToggleValueProvider. Can be used as provider for feature toggles inheriting from FeatureToggle.EnabledOnOrAfterDateFeatureToggle or FeatureToggle.EnabledOnOrBeforeDateFeatureToggle.
 1.0.0
 - Initial release</PackageReleaseNotes>
     <PackageTags>FeatureToggle Toggle Azure TableStorage Table Storage NetStandard</PackageTags>
     <Description>FeatureToggle provider for storing feature toggles in Azure Table storage.</Description>
-    <Version>1.1.0</Version>
+    <Version>1.2.0</Version>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/FeatureToggle.Azure.TableStorage/Providers/TableStorageProvider.cs
+++ b/src/FeatureToggle.Azure.TableStorage/Providers/TableStorageProvider.cs
@@ -5,7 +5,7 @@ using System.Diagnostics;
 
 namespace FeatureToggle.Azure.Providers
 {
-    public class TableStorageProvider : IBooleanToggleValueProvider, IDateTimeToggleValueProvider
+    public class TableStorageProvider : IBooleanToggleValueProvider, IDateTimeToggleValueProvider, ITimePeriodProvider
     {
         private static bool _tableVerified;
 
@@ -34,6 +34,14 @@ namespace FeatureToggle.Azure.Providers
         public DateTime EvaluateDateTimeToggleValue(IFeatureToggle toggle)
         {
             return EvaluateToggleValue(toggle, entity => entity.ToggleTimestamp, (componentName, toggleName) => new DateTimeFeatureToggleEntity(componentName, toggleName));
+        }
+
+        public Tuple<DateTime, DateTime> EvaluateTimePeriod(IFeatureToggle toggle)
+        {
+            return EvaluateToggleValue(toggle, entity => 
+            {
+                return new Tuple<DateTime, DateTime>(entity.EnabledFrom, entity.EnabledTo);
+            }, (componentName, toggleName) => new TimePeriodFeatureToggleEntity(componentName, toggleName));
         }
 
         private TValue EvaluateToggleValue<TEntity, TValue>(IFeatureToggle toggle, Func<TEntity, TValue> valueSelector, Func<string, string, TEntity> entityCreator) where TEntity : FeatureToggleEntity

--- a/src/FeatureToggle.Azure.TableStorage/Providers/TableStorageProvider.cs
+++ b/src/FeatureToggle.Azure.TableStorage/Providers/TableStorageProvider.cs
@@ -39,7 +39,7 @@ namespace FeatureToggle.Azure.Providers
         public Tuple<DateTime, DateTime> EvaluateTimePeriod(IFeatureToggle toggle)
         {
             return EvaluateToggleValue(toggle, 
-                entity => new Tuple<DateTime, DateTime>(entity.EnabledFrom, entity.EnabledTo), 
+                entity => new Tuple<DateTime, DateTime>(entity.Start, entity.End), 
                 (componentName, toggleName) => new TimePeriodFeatureToggleEntity(componentName, toggleName));
         }
 

--- a/src/FeatureToggle.Azure.TableStorage/Providers/TableStorageProvider.cs
+++ b/src/FeatureToggle.Azure.TableStorage/Providers/TableStorageProvider.cs
@@ -38,10 +38,9 @@ namespace FeatureToggle.Azure.Providers
 
         public Tuple<DateTime, DateTime> EvaluateTimePeriod(IFeatureToggle toggle)
         {
-            return EvaluateToggleValue(toggle, entity => 
-            {
-                return new Tuple<DateTime, DateTime>(entity.EnabledFrom, entity.EnabledTo);
-            }, (componentName, toggleName) => new TimePeriodFeatureToggleEntity(componentName, toggleName));
+            return EvaluateToggleValue(toggle, 
+                entity => new Tuple<DateTime, DateTime>(entity.EnabledFrom, entity.EnabledTo), 
+                (componentName, toggleName) => new TimePeriodFeatureToggleEntity(componentName, toggleName));
         }
 
         private TValue EvaluateToggleValue<TEntity, TValue>(IFeatureToggle toggle, Func<TEntity, TValue> valueSelector, Func<string, string, TEntity> entityCreator) where TEntity : FeatureToggleEntity

--- a/src/FeatureToggle.Azure.TableStorage/Providers/TimePeriodFeatureToggleEntity.cs
+++ b/src/FeatureToggle.Azure.TableStorage/Providers/TimePeriodFeatureToggleEntity.cs
@@ -1,0 +1,19 @@
+﻿using System;
+
+namespace FeatureToggle.Azure.Providers
+{
+    public class TimePeriodFeatureToggleEntity : FeatureToggleEntity
+    {
+        public TimePeriodFeatureToggleEntity() : base() { }
+
+        public TimePeriodFeatureToggleEntity(string componentName, string toggleName) : base(componentName, toggleName)
+        {
+            // Table Storage does not support DateTime.Min
+            EnabledFrom = new DateTime(1900, 1, 1); 
+            EnabledTo = new DateTime(1900, 1, 1); 
+        }
+
+        public DateTime EnabledFrom { get; set; }
+        public DateTime EnabledTo { get; set; }
+    }
+}

--- a/src/FeatureToggle.Azure.TableStorage/Providers/TimePeriodFeatureToggleEntity.cs
+++ b/src/FeatureToggle.Azure.TableStorage/Providers/TimePeriodFeatureToggleEntity.cs
@@ -9,11 +9,11 @@ namespace FeatureToggle.Azure.Providers
         public TimePeriodFeatureToggleEntity(string componentName, string toggleName) : base(componentName, toggleName)
         {
             // Table Storage does not support DateTime.Min
-            EnabledFrom = new DateTime(1900, 1, 1); 
-            EnabledTo = new DateTime(1900, 1, 1); 
+            Start = new DateTime(1900, 1, 1); 
+            End = new DateTime(1900, 1, 1); 
         }
 
-        public DateTime EnabledFrom { get; set; }
-        public DateTime EnabledTo { get; set; }
+        public DateTime Start { get; set; }
+        public DateTime End { get; set; }
     }
 }

--- a/test/FeatureToggle.Azure.DocumentDB.Test/TimePeriodToggleTest.cs
+++ b/test/FeatureToggle.Azure.DocumentDB.Test/TimePeriodToggleTest.cs
@@ -1,0 +1,55 @@
+﻿using FeatureToggle.Azure.DocumentDB.Test.Toggles;
+using FeatureToggle.Azure.Providers;
+using NUnit.Framework;
+using Shouldly;
+using System;
+using System.Threading.Tasks;
+
+namespace FeatureToggle.Azure.DocumentDB.Test
+{
+    [TestFixture]
+    public class TimePeriodToggleTest : DocumentDbTestFixture
+    {
+        [Test]
+        public async Task FeatureEnabled_LimitedTimeOfferFeatureToggleSetToEnabledTomorrow_ToggleValueIsFalse()
+        {
+            // Arrange
+            AutoCreateToggle<LimitedTimeOfferFeatureToggle>();
+            await UpdateToggleDocument(new TimePeriodFeatureToggleDocument(nameof(LimitedTimeOfferFeatureToggle)) { EnabledFrom = DateTime.Now.AddDays(1), EnabledTo = DateTime.Now.AddDays(2) });
+
+            var toggle = new LimitedTimeOfferFeatureToggle();
+            // Act
+            var toggleValue = toggle.FeatureEnabled;
+            // Assert
+            toggleValue.ShouldBeFalse();
+        }
+
+        [Test]
+        public async Task FeatureEnabled_LimitedTimeOfferFeatureToggleSetToExpiredYesterday_ToggleValueIsFalse()
+        {
+            // Arrange
+            AutoCreateToggle<LimitedTimeOfferFeatureToggle>();
+            await UpdateToggleDocument(new TimePeriodFeatureToggleDocument(nameof(LimitedTimeOfferFeatureToggle)) { EnabledFrom = DateTime.Now.AddDays(-2), EnabledTo = DateTime.Now.AddDays(-1) });
+
+            var toggle = new LimitedTimeOfferFeatureToggle();
+            // Act
+            var toggleValue = toggle.FeatureEnabled;
+            // Assert
+            toggleValue.ShouldBeFalse();
+        }
+
+        [Test]
+        public async Task FeatureEnabled_LimitedTimeOfferFeatureToggleSetToEnabledYesterday_ToggleValueIsTrue()
+        {
+            // Arrange
+            AutoCreateToggle<LimitedTimeOfferFeatureToggle>();
+            await UpdateToggleDocument(new TimePeriodFeatureToggleDocument(nameof(LimitedTimeOfferFeatureToggle)) { EnabledFrom = DateTime.Now.AddDays(-1), EnabledTo = DateTime.Now.AddDays(1) });
+
+            var toggle = new LimitedTimeOfferFeatureToggle();
+            // Act
+            var toggleValue = toggle.FeatureEnabled;
+            // Assert
+            toggleValue.ShouldBeTrue();
+        }
+    }
+}

--- a/test/FeatureToggle.Azure.DocumentDB.Test/TimePeriodToggleTest.cs
+++ b/test/FeatureToggle.Azure.DocumentDB.Test/TimePeriodToggleTest.cs
@@ -15,7 +15,7 @@ namespace FeatureToggle.Azure.DocumentDB.Test
         {
             // Arrange
             AutoCreateToggle<LimitedTimeOfferFeatureToggle>();
-            await UpdateToggleDocument(new TimePeriodFeatureToggleDocument(nameof(LimitedTimeOfferFeatureToggle)) { EnabledFrom = DateTime.Now.AddDays(1), EnabledTo = DateTime.Now.AddDays(2) });
+            await UpdateToggleDocument(new TimePeriodFeatureToggleDocument(nameof(LimitedTimeOfferFeatureToggle)) { Start = DateTime.Now.AddDays(1), End = DateTime.Now.AddDays(2) });
 
             var toggle = new LimitedTimeOfferFeatureToggle();
             // Act
@@ -29,7 +29,7 @@ namespace FeatureToggle.Azure.DocumentDB.Test
         {
             // Arrange
             AutoCreateToggle<LimitedTimeOfferFeatureToggle>();
-            await UpdateToggleDocument(new TimePeriodFeatureToggleDocument(nameof(LimitedTimeOfferFeatureToggle)) { EnabledFrom = DateTime.Now.AddDays(-2), EnabledTo = DateTime.Now.AddDays(-1) });
+            await UpdateToggleDocument(new TimePeriodFeatureToggleDocument(nameof(LimitedTimeOfferFeatureToggle)) { Start = DateTime.Now.AddDays(-2), End = DateTime.Now.AddDays(-1) });
 
             var toggle = new LimitedTimeOfferFeatureToggle();
             // Act
@@ -43,7 +43,7 @@ namespace FeatureToggle.Azure.DocumentDB.Test
         {
             // Arrange
             AutoCreateToggle<LimitedTimeOfferFeatureToggle>();
-            await UpdateToggleDocument(new TimePeriodFeatureToggleDocument(nameof(LimitedTimeOfferFeatureToggle)) { EnabledFrom = DateTime.Now.AddDays(-1), EnabledTo = DateTime.Now.AddDays(1) });
+            await UpdateToggleDocument(new TimePeriodFeatureToggleDocument(nameof(LimitedTimeOfferFeatureToggle)) { Start = DateTime.Now.AddDays(-1), End = DateTime.Now.AddDays(1) });
 
             var toggle = new LimitedTimeOfferFeatureToggle();
             // Act

--- a/test/FeatureToggle.Azure.DocumentDB.Test/Toggles/LimitedTimeOfferFeatureToggle.cs
+++ b/test/FeatureToggle.Azure.DocumentDB.Test/Toggles/LimitedTimeOfferFeatureToggle.cs
@@ -1,0 +1,15 @@
+﻿using FeatureToggle.Azure.Providers;
+using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace FeatureToggle.Azure.DocumentDB.Test.Toggles
+{
+    public class LimitedTimeOfferFeatureToggle : EnabledBetweenDatesFeatureToggle
+    {
+        public LimitedTimeOfferFeatureToggle()
+        {
+            this.ToggleValueProvider = new DocumentDbProvider();
+        }
+    }
+}

--- a/test/FeatureToggle.Azure.ServiceFabric.Test/TimePeriodToggleTest.cs
+++ b/test/FeatureToggle.Azure.ServiceFabric.Test/TimePeriodToggleTest.cs
@@ -1,0 +1,91 @@
+﻿using FeatureToggle.Azure.Providers;
+using FeatureToggle.Azure.ServiceFabric.Test.Toggles;
+using NUnit.Framework;
+using Shouldly;
+using System;
+using System.Collections.Generic;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace FeatureToggle.Azure.ServiceFabric.Test
+{
+
+    [TestFixture]
+    public class TimePeriodToggleTest : ServiceFabricTestFixture
+    {
+        private const string ExpectedDateFormat = @"dd-MMM-yyyy HH:mm:ss";
+
+        [SetUp]
+        public void Setup()
+        {
+            ServiceFabricConfigProvider.Configure(usePrefix: false);
+        }
+
+        [Test]        
+        public void FeatureEnabled_LimitedTimeOfferFeatureToggleSetToEnabledTomorrow_ToggleValueIsFalse()
+        {
+            // Arrange
+            DateTime start = DateTime.Today.AddDays(1);
+            DateTime end = DateTime.Today.AddDays(2);
+            string configValue = $"{start:dd-MMM-yyyy HH:mm:ss} | {end:dd-MMM-yyyy HH:mm:ss}";
+            SetToggleInConfig(nameof(LimitedTimeOfferFeatureToggle), configValue);
+            var toggle = new LimitedTimeOfferFeatureToggle();
+            // Act
+            var toggleValue = toggle.FeatureEnabled;
+            // Assert
+            toggleValue.ShouldBeFalse();
+        }
+
+        [Test]
+        public void FeatureEnabled_LimitedTimeOfferFeatureToggleSetToExpiredYesterday_ToggleValueIsFalse()
+        {
+            // Arrange
+            DateTime start = DateTime.Today.AddDays(-2);
+            DateTime end = DateTime.Today.AddDays(-1);
+            string configValue = $"{start:dd-MMM-yyyy HH:mm:ss} | {end:dd-MMM-yyyy HH:mm:ss}";
+            SetToggleInConfig(nameof(LimitedTimeOfferFeatureToggle), configValue);
+            var toggle = new LimitedTimeOfferFeatureToggle();
+            // Act
+            var toggleValue = toggle.FeatureEnabled;
+            // Assert
+            toggleValue.ShouldBeFalse();
+        }
+
+        [Test]
+        public void FeatureEnabled_LimitedTimeOfferFeatureToggleSetToEnabledYesterday_ToggleValueIsTrue()
+        {
+            // Arrange            
+            DateTime start = DateTime.Today.AddDays(-1);
+            DateTime end = DateTime.Today.AddDays(1);
+            string configValue = $"{start:dd-MMM-yyyy HH:mm:ss} | {end:dd-MMM-yyyy HH:mm:ss}";
+            SetToggleInConfig(nameof(LimitedTimeOfferFeatureToggle), configValue);
+            var toggle = new LimitedTimeOfferFeatureToggle();
+            // Act
+            var toggleValue = toggle.FeatureEnabled;
+            // Assert
+            toggleValue.ShouldBeTrue();
+        }        
+
+        [TestCase("02-Jan-2050 04:05:10 | 02-Jan-2050 04:05:09", "the start date must be less then the end date")]
+        [TestCase("02-Jan-2050 04:05:09 | 02-Jan-2050 04:05:09", "the start date must be less then the end date")]
+        [TestCase("01-Jan-2050 04:05:09 | 02/01/2050 04:05:44", "cannot be converted to a DateTime")]
+        [TestCase("qwerty | 07-Aug-2099 06:05:04", "cannot be converted to a DateTime")]
+        [TestCase("02-Jan-2050 04:05:08 ; 07-Aug-2099 06:05:04", "cannot be converted to a DateTime")]
+        [TestCase("02-Jan-2050 04:05:08 | qwerty", "cannot be converted to a DateTime")]
+        public void FeatureEnabled_ComingSoonFeatureToggleSetToInvalidDate_ThrowToggleConfigError(string configValue, string errorMsg)
+        {
+            // Arrange
+            SetToggleInConfig(nameof(LimitedTimeOfferFeatureToggle), configValue);
+            var toggle = new LimitedTimeOfferFeatureToggle();
+
+            var error = Should.Throw<ToggleConfigurationError>(() =>
+            {
+                // Act
+                var toggleValue = toggle.FeatureEnabled;
+            });
+
+            // Assert
+            error.Message.ShouldContain(errorMsg);
+        }
+    }
+}

--- a/test/FeatureToggle.Azure.ServiceFabric.Test/Toggles/LimitedTimeOfferFeatureToggle.cs
+++ b/test/FeatureToggle.Azure.ServiceFabric.Test/Toggles/LimitedTimeOfferFeatureToggle.cs
@@ -1,0 +1,15 @@
+﻿using FeatureToggle.Azure.Providers;
+using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace FeatureToggle.Azure.ServiceFabric.Test.Toggles
+{
+    public class LimitedTimeOfferFeatureToggle : EnabledBetweenDatesFeatureToggle
+    {
+        public LimitedTimeOfferFeatureToggle()
+        {
+            this.ToggleValueProvider = new ServiceFabricConfigProvider();
+        }
+    }
+}

--- a/test/FeatureToggle.Azure.TableStorage.Test/TimePeriodToggleTest.cs
+++ b/test/FeatureToggle.Azure.TableStorage.Test/TimePeriodToggleTest.cs
@@ -17,7 +17,7 @@ namespace FeatureToggle.Azure.TableStorage.Test
         {
             // Arrange
             AutoCreateToggle<LimitedTimeOfferFeatureToggle>();
-            await UpdateToggleEntity(new TimePeriodFeatureToggleEntity(partitionKey, nameof(LimitedTimeOfferFeatureToggle)) { EnabledFrom = DateTime.Now.AddDays(1), EnabledTo = DateTime.Now.AddDays(2) });
+            await UpdateToggleEntity(new TimePeriodFeatureToggleEntity(partitionKey, nameof(LimitedTimeOfferFeatureToggle)) { Start = DateTime.Now.AddDays(1), End = DateTime.Now.AddDays(2) });
 
             var toggle = new LimitedTimeOfferFeatureToggle();
             // Act
@@ -31,7 +31,7 @@ namespace FeatureToggle.Azure.TableStorage.Test
         {
             // Arrange
             AutoCreateToggle<LimitedTimeOfferFeatureToggle>();
-            await UpdateToggleEntity(new TimePeriodFeatureToggleEntity(partitionKey, nameof(LimitedTimeOfferFeatureToggle)) { EnabledFrom = DateTime.Now.AddDays(-2), EnabledTo = DateTime.Now.AddDays(-1) });
+            await UpdateToggleEntity(new TimePeriodFeatureToggleEntity(partitionKey, nameof(LimitedTimeOfferFeatureToggle)) { Start = DateTime.Now.AddDays(-2), End = DateTime.Now.AddDays(-1) });
 
             var toggle = new LimitedTimeOfferFeatureToggle();
             // Act
@@ -45,7 +45,7 @@ namespace FeatureToggle.Azure.TableStorage.Test
         {
             // Arrange
             AutoCreateToggle<LimitedTimeOfferFeatureToggle>();
-            await UpdateToggleEntity(new TimePeriodFeatureToggleEntity(partitionKey, nameof(LimitedTimeOfferFeatureToggle)) { EnabledFrom = DateTime.Now.AddDays(-1), EnabledTo = DateTime.Now.AddDays(1) });
+            await UpdateToggleEntity(new TimePeriodFeatureToggleEntity(partitionKey, nameof(LimitedTimeOfferFeatureToggle)) { Start = DateTime.Now.AddDays(-1), End = DateTime.Now.AddDays(1) });
 
             var toggle = new LimitedTimeOfferFeatureToggle();
             // Act

--- a/test/FeatureToggle.Azure.TableStorage.Test/TimePeriodToggleTest.cs
+++ b/test/FeatureToggle.Azure.TableStorage.Test/TimePeriodToggleTest.cs
@@ -1,0 +1,57 @@
+﻿using FeatureToggle.Azure.Providers;
+using FeatureToggle.Azure.TableStorage.Test.Toggles;
+using NUnit.Framework;
+using Shouldly;
+using System;
+using System.Collections.Generic;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace FeatureToggle.Azure.TableStorage.Test
+{
+    [TestFixture]
+    public class TimePeriodToggleTest : TableStorageTestFixture
+    {
+        [Test]
+        public async Task FeatureEnabled_LimitedTimeOfferFeatureToggleSetToEnabledTomorrow_ToggleValueIsFalse()
+        {
+            // Arrange
+            AutoCreateToggle<LimitedTimeOfferFeatureToggle>();
+            await UpdateToggleEntity(new TimePeriodFeatureToggleEntity(partitionKey, nameof(LimitedTimeOfferFeatureToggle)) { EnabledFrom = DateTime.Now.AddDays(1), EnabledTo = DateTime.Now.AddDays(2) });
+
+            var toggle = new LimitedTimeOfferFeatureToggle();
+            // Act
+            var toggleValue = toggle.FeatureEnabled;
+            // Assert
+            toggleValue.ShouldBeFalse();
+        }
+
+        [Test]
+        public async Task FeatureEnabled_LimitedTimeOfferFeatureToggleSetToExpiredYesterday_ToggleValueIsFalse()
+        {
+            // Arrange
+            AutoCreateToggle<LimitedTimeOfferFeatureToggle>();
+            await UpdateToggleEntity(new TimePeriodFeatureToggleEntity(partitionKey, nameof(LimitedTimeOfferFeatureToggle)) { EnabledFrom = DateTime.Now.AddDays(-2), EnabledTo = DateTime.Now.AddDays(-1) });
+
+            var toggle = new LimitedTimeOfferFeatureToggle();
+            // Act
+            var toggleValue = toggle.FeatureEnabled;
+            // Assert
+            toggleValue.ShouldBeFalse();
+        }
+
+        [Test]
+        public async Task FeatureEnabled_LimitedTimeOfferFeatureToggleSetToEnabledYesterday_ToggleValueIsTrue()
+        {
+            // Arrange
+            AutoCreateToggle<LimitedTimeOfferFeatureToggle>();
+            await UpdateToggleEntity(new TimePeriodFeatureToggleEntity(partitionKey, nameof(LimitedTimeOfferFeatureToggle)) { EnabledFrom = DateTime.Now.AddDays(-1), EnabledTo = DateTime.Now.AddDays(1) });
+
+            var toggle = new LimitedTimeOfferFeatureToggle();
+            // Act
+            var toggleValue = toggle.FeatureEnabled;
+            // Assert
+            toggleValue.ShouldBeTrue();
+        }
+    }
+}

--- a/test/FeatureToggle.Azure.TableStorage.Test/Toggles/LimitedTimeOfferFeatureToggle.cs
+++ b/test/FeatureToggle.Azure.TableStorage.Test/Toggles/LimitedTimeOfferFeatureToggle.cs
@@ -1,0 +1,15 @@
+﻿using FeatureToggle.Azure.Providers;
+using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace FeatureToggle.Azure.TableStorage.Test.Toggles
+{
+    public class LimitedTimeOfferFeatureToggle : EnabledBetweenDatesFeatureToggle
+    {
+        public LimitedTimeOfferFeatureToggle()
+        {
+            this.ToggleValueProvider = new TableStorageProvider();
+        }
+    }
+}


### PR DESCRIPTION
All providers now implement the ITimeProvider interface for time limited feature toggles, that inherit from FeatureToggle.EnabledBetweenDatesFeatureToggle

Unit test/integration test for all providers implementing this new feature.